### PR TITLE
Add wslpath to Windows versions older than 1803

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Vcs-Git: https://github.com/WhitewaterFoundry/pengwin-setup.git
 
 Package: pengwin-setup
 Architecture: all
-Depends: ${misc:Depends}, git, wslu, pengwin-base (>= 0.1-134)
+Depends: ${misc:Depends}, git, wslu, pengwin-base (>= 0.1-175)
 Description: Setup tool for Pengwin.
 Essential: yes

--- a/pengwin-setup.d/common.sh
+++ b/pengwin-setup.d/common.sh
@@ -108,6 +108,11 @@ function setup_env() {
 
   process_arguments "$@"
 
+  if ( ! wslpath > /dev/null 2>&1 ); then
+    shopt -s expand_aliases
+    alias wslpath=legacy_wslupath
+  fi
+
   readonly wHomeWinPath=$(cmd-exe /c 'echo %HOMEDRIVE%%HOMEPATH%' | tr -d '\r')
   readonly wHome=$(wslpath -u "${wHomeWinPath}")
   readonly CANCELLED="CANCELLED"


### PR DESCRIPTION
This change depends on a certain pengwin-base version. This PR will be updated when this version be released to declare the dependency.