### PR TITLE
Install brew

### DIFF
--- a/pengwin-setup.d/brew.sh
+++ b/pengwin-setup.d/brew.sh
@@ -4,6 +4,8 @@ source $(dirname "$0")/common.sh "$@"
 
 if (whiptail --title "HOMEBREW" --yesno "Would you like to download and install the Homebrew package manager? Transitioning macOS users may find this more familiar, and others may use this to install both software not provided by APT, or newer versions of software not yet in APT repositories." 12 85) then
 	echo "Installing Homebrew"
+	whiptail --title "HOMEBREW" --msgbox "Please note, with Homebrew you can install many of the same packages at the same time as those offered by APT, or even offered by pengwin-setup. This is possible as Homebrew installs packages locally to:\n/home/linuxbrew\nTo allow forcing use of packages installed by a specific source, you may add an alias to them in:\n/etc/profile.d/99-alias-overrides.sh" 14 85
+	sudo bash -c ''
 
 	# Check we have correct dependencies installed for brew
 	echo "Installing Homebrew dependencies"

--- a/pengwin-setup.d/brew.sh
+++ b/pengwin-setup.d/brew.sh
@@ -5,7 +5,13 @@ source $(dirname "$0")/common.sh "$@"
 if (whiptail --title "HOMEBREW" --yesno "Would you like to download and install the Homebrew package manager? Transitioning macOS users may find this more familiar, and others may use this to install both software not provided by APT, or newer versions of software not yet in APT repositories." 12 85) then
 	echo "Installing Homebrew"
 	whiptail --title "HOMEBREW" --msgbox "Please note, with Homebrew you can install many of the same packages at the same time as those offered by APT, or even offered by pengwin-setup. This is possible as Homebrew installs packages locally to:\n/home/linuxbrew\nTo allow forcing use of packages installed by a specific source, you may add an alias to them in:\n/etc/profile.d/99-alias-overrides.sh" 14 85
-	sudo bash -c ''
+	if [[ ! -f "/etc/profile.d/99-alias-overrides.sh" ]] ; then
+		echo "Existing 99-alias-overrides.sh not found. Creating..."
+		sudo bash -c 'cat > /etc/profile.d/99-alias-overrides.sh' << EOF
+# Example override
+# alias rbenv='/home/linuxbrew/.linuxbrew/bin/rbenv'
+EOF
+	fi
 
 	# Check we have correct dependencies installed for brew
 	echo "Installing Homebrew dependencies"

--- a/pengwin-setup.d/brew.sh
+++ b/pengwin-setup.d/brew.sh
@@ -7,14 +7,14 @@ if (whiptail --title "HOMEBREW" --yesno "Would you like to download and install 
 
 	# Check we have correct dependencies installed for brew
 	echo "Installing Homebrew dependencies"
-	sudo apt-get -y -q -t build-essential curl file git
+	sudo apt-get install -y -q build-essential curl file git
 
 	whiptail --title "HOMEBREW" --msgbox "Please press enter when asked to continue by the Homebrew installer." 7 85
-	sh -c "$(curl -fsSL https://raw.githubusercontent.com/LinuxBrew/install/master/install.sh)"
+	sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 
 	echo "Adding Homebrew to system path"
-	sudo bash -c 'echo "eval \$($(brew --prefix)/bin/brew shellenv)" > /etc/profile/brew.sh'
-	source /etc/profile/brew.sh
+	sudo bash -c 'echo "eval \$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" > /etc/profile.d/brew.sh'
+	bash /etc/profile.d/brew.sh
 
 	whiptail --title "HOMEBREW" --msgbox "Please note, Homebrew does record and share analytics information (more information here: https://docs.brew.sh/Analytics.html). To opt-out, type:\n\`brew analytics off\`" 9 85
 else

--- a/pengwin-setup.d/brew.sh
+++ b/pengwin-setup.d/brew.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh "$@"
+
+if (whiptail --title "HOMEBREW" --yesno "Would you like to download and install the Homebrew package manager? Transitioning macOS users may find this more familiar, and others may use this to install both software not provided by APT, or newer versions of software not yet in APT repositories." 12 85) then
+	echo "Installing Homebrew"
+
+	# Check we have correct dependencies installed for brew
+	echo "Installing Homebrew dependencies"
+	sudo apt-get -y -q -t build-essential curl file git
+
+	whiptail --title "HOMEBREW" --msgbox "Please press enter when asked to continue by the Homebrew installer." 7 85
+	sh -c "$(curl -fsSL https://raw.githubusercontent.com/LinuxBrew/install/master/install.sh)"
+
+	echo "Adding Homebrew to system path"
+	sudo bash -c 'echo "eval \$($(brew --prefix)/bin/brew shellenv)" > /etc/profile/brew.sh'
+	source /etc/profile/brew.sh
+
+	whiptail --title "HOMEBREW" --msgbox "Please note, Homebrew does record and share analytics information (more information here: https://docs.brew.sh/Analytics.html). To opt-out, type:\n\`brew analytics off\`" 9 85
+else
+	echo "Skipping HOMEBREW"
+fi

--- a/pengwin-setup.d/tools.sh
+++ b/pengwin-setup.d/tools.sh
@@ -7,11 +7,11 @@ function main() {
   local menu_choice=$(
 
     menu --title "Tools Menu" --checklist --separate-output "Install applications or servers\n[SPACE to select, ENTER to confirm]:" 12 70 3 \
+      "HOMEBREW" "Install the Homebrew package manager" off \
       "ANSIBLE" "Install tools to deploy Ansible Playbooks" off \
       "CLOUDCLI" "Install CLI tools for cloud management" off \
       "DOCKER" "Install a secure bridge to Docker Desktop" off \
       "POWERSHELL" "Install PowerShell for Linux" off \
-
   3>&1 1>&2 2>&3)
 
   if [[ ${menu_choice} == "CANCELLED" ]] ; then
@@ -38,7 +38,10 @@ function main() {
     bash ${SetupDir}/powershell.sh "$@"
   fi
 
-
+  if [[ ${menu_choice} == *"HOMEBREW"* ]] ; then
+    echo "HOMEBREW"
+    bash ${SetupDir}/brew.sh "$@"
+  fi
 }
 
 main "$@"

--- a/pengwin-setup.d/tools.sh
+++ b/pengwin-setup.d/tools.sh
@@ -6,12 +6,13 @@ function main() {
 
   local menu_choice=$(
 
-    menu --title "Tools Menu" --checklist --separate-output "Install applications or servers\n[SPACE to select, ENTER to confirm]:" 12 70 3 \
+    menu --title "Tools Menu" --checklist --separate-output "Install applications or servers\n[SPACE to select, ENTER to confirm]:" 12 70 5 \
       "HOMEBREW" "Install the Homebrew package manager" off \
       "ANSIBLE" "Install tools to deploy Ansible Playbooks" off \
       "CLOUDCLI" "Install CLI tools for cloud management" off \
       "DOCKER" "Install a secure bridge to Docker Desktop" off \
       "POWERSHELL" "Install PowerShell for Linux" off \
+
   3>&1 1>&2 2>&3)
 
   if [[ ${menu_choice} == "CANCELLED" ]] ; then
@@ -42,6 +43,7 @@ function main() {
     echo "HOMEBREW"
     bash ${SetupDir}/brew.sh "$@"
   fi
+
 }
 
 main "$@"


### PR DESCRIPTION
Install the Homebrew package manager. Tested and seems to be working on my install, further testing obviously needed. Compatibilty with (and possible workarounds to) conflicting installs between pengwin-setup and Homebrew need to be looked into.

~I've checked and it is possilbe to install rbenv or pyenv from both pengwin-setup and Homebrew, but it tends to default to whichever was most recently installed (rbenv or Homebrew that is). We could display a warning at the beginning of the Homebrew install script?~