### PR TITLE
Loginshell path fix

### DIFF
--- a/login_shell
+++ b/login_shell
@@ -5,6 +5,14 @@ if [ "${@}" ] ; then
 fi
 
 # Proposed fix for PATH on Windows 10 1903+
+if echo $PATH | grep -Fqe '%USERPROFILE%' ; then
+	if echo $PATH | grep -Fqe '/mnt/' ; then
+		PATH="$(echo $PATH | sed 's|:/%USERPROFILE%/AppData/Local/Microsoft/WindowsApps||g')"
+		export PATH
+	else
+		echo "Unable to find system drive from \$PATH. Please relaunch Pengwin from the Start Menu"
+	fi
+fi
 if echo $PATH | grep -Fqe '%SYSTEMROOT%' ; then
 	SystemDrive="$(echo $PATH | sed 's|:|\n|g' | grep 'AppData/Local/Microsoft/WindowsApps' | cut -d$'\n' -f1 | sed 's|/Users/.*/AppData/Local/Microsoft/WindowsApps||g')"
 	SystemRoot="$SystemDrive/WINDOWS"

--- a/login_shell
+++ b/login_shell
@@ -4,24 +4,15 @@ if [ "${@}" ] ; then
 	cd "$(wslpath "${@}")"
 fi
 
-if ! echo $PATH | grep -Fqi 'WINDOWS/System32:' ; then
+if echo $PATH | grep -Fqi '%SYSTEMROOT%' ; then
 	if ! echo $PATH | grep -Fqi 'AppData/Local/Microsoft/WindowsApps' ; then
 		echo "Unable to find system-drive mount point from \$PATH. Please relaunch Pengwin from the Start Menu"
-	fi
-
-	SystemDrive="$(echo $PATH | sed 's|:|\n|g' | grep 'AppData/Local/Microsoft/WindowsApps' | cut -d$'\n' -f1 | sed 's|/Users/.*/AppData/Local/Microsoft/WindowsApps||g')"
-	SystemRoot="$SystemDrive/WINDOWS"
-	if echo $PATH | grep -Fqi '%SYSTEMROOT%' ; then
-		PATH="$(echo $PATH | sed 's|/%SystemRoot%|'"$SystemRoot"'|gI')"
 	else
-		P_System32="$SystemRoot/System32"
-		P_SystemRoot="$SystemRoot"
-		P_Sys32Wbem="$P_System32/Wbem"
-		P_Sys32PowerShell="$P_System32/WindowsPowerShell/v1.0"
-		P_Sys32OpenSSH="$P_System32/OpenSSH"
-		PATH="$PATH:$P_System32:$P_SystemRoot:$P_Sys32Wbem:$P_Sys32PowerShell:$P_Sys32OpenSSH"
+		SystemDrive="$(echo $PATH | sed 's|:|\n|g' | grep 'AppData/Local/Microsoft/WindowsApps' | cut -d$'\n' -f1 | sed 's|/Users/.*/AppData/Local/Microsoft/WindowsApps||g')"
+		SystemRoot="$SystemDrive/WINDOWS"
+		PATH="$(echo $PATH | sed 's|/%SystemRoot%|'"$SystemRoot"'|gI')"
+		export PATH
 	fi
-	export PATH
 fi
 
 $(getent passwd $LOGNAME | cut -d: -f7) --login

--- a/login_shell
+++ b/login_shell
@@ -4,25 +4,23 @@ if [ "${@}" ] ; then
 	cd "$(wslpath "${@}")"
 fi
 
-# Proposed fix for PATH when user home has spaces (on Windows 10 1903+)
-if echo $PATH | grep -Fqe '%USERPROFILE%' ; then
-	if echo $PATH | grep -Fqe '/mnt/' ; then
-		PATH="$(echo $PATH | sed 's|:/%USERPROFILE%/AppData/Local/Microsoft/WindowsApps||g')"
-		export PATH
-	else
-		echo "Unable to find system drive from \$PATH. Please relaunch Pengwin from the Start Menu"
+if ! echo $PATH | grep -Fqi 'WINDOWS/System32:' ; then
+	if ! echo $PATH | grep -Fqi 'AppData/Local/Microsoft/WindowsApps' ; then
+		echo "Unable to find system-drive mount point from \$PATH. Please relaunch Pengwin from the Start Menu"
 	fi
-fi
-if echo $PATH | grep -Fqe '%SYSTEMROOT%' ; then
+
 	SystemDrive="$(echo $PATH | sed 's|:|\n|g' | grep 'AppData/Local/Microsoft/WindowsApps' | cut -d$'\n' -f1 | sed 's|/Users/.*/AppData/Local/Microsoft/WindowsApps||g')"
 	SystemRoot="$SystemDrive/WINDOWS"
-	PATH="$(echo $PATH | sed 's|/%SYSTEMROOT%|'"$SystemRoot"'|g')"
-	export PATH
-fi
-if echo $PATH | grep -Fqe '%SystemRoot%' ; then
-	SystemDrive="$(echo $PATH | sed 's|:|\n|g' | grep 'AppData/Local/Microsoft/WindowsApps' | cut -d$'\n' -f1 | sed 's|/Users/.*/AppData/Local/Microsoft/WindowsApps||g')"
-	SystemRoot="$SystemDrive/WINDOWS"
-	PATH="$(echo $PATH | sed 's|/%SystemRoot%|'"$SystemRoot"'|g')"
+	if echo $PATH | grep -Fqi '%SYSTEMROOT%' ; then
+		PATH="$(echo $PATH | sed 's|/%SystemRoot%|'"$SystemRoot"'|gI')"
+	else
+		P_System32="$SystemRoot/System32"
+		P_SystemRoot="$SystemRoot"
+		P_Sys32Wbem="$P_System32/Wbem"
+		P_Sys32PowerShell="$P_System32/WindowsPowerShell/v1.0"
+		P_Sys32OpenSSH="$P_System32/OpenSSH"
+		PATH="$PATH:$P_System32:$P_SystemRoot:$P_Sys32Wbem:$P_Sys32PowerShell:$P_Sys32OpenSSH"
+	fi
 	export PATH
 fi
 

--- a/login_shell
+++ b/login_shell
@@ -4,7 +4,7 @@ if [ "${@}" ] ; then
 	cd "$(wslpath "${@}")"
 fi
 
-# Proposed fix for PATH on Windows 10 1903+
+# Proposed fix for PATH when user home has spaces (on Windows 10 1903+)
 if echo $PATH | grep -Fqe '%USERPROFILE%' ; then
 	if echo $PATH | grep -Fqe '/mnt/' ; then
 		PATH="$(echo $PATH | sed 's|:/%USERPROFILE%/AppData/Local/Microsoft/WindowsApps||g')"


### PR DESCRIPTION
Update fix for PATH with explorer integration when user home has spaces (on Windows 10 1903+). This issue only shows up on my Windows install where my user home folder is 'kim (grufwub)', whereas the other install with 'kimja' has no issues. This is likely mitigating an upstream issue.