### PR TITLE
Manually export path + eval pyenv in pythonpi.sh

### DIFF
--- a/pengwin-setup.d/pythonpi.sh
+++ b/pengwin-setup.d/pythonpi.sh
@@ -10,34 +10,33 @@ if (whiptail --title "PYTHON" --yesno "Would you like to download and install Py
     bash pyenv-installer
 
     echo "inserting default scripts"
-    
+
     if [ -f ${HOME}/.bashrc ]; then
      	echo "export PATH=\"${HOME}/.pyenv/bin:\$PATH\"" >> ${HOME}/.bashrc
       	echo "eval \"\$(pyenv init -)\"" >> ${HOME}/.bashrc
       	echo "eval \"\$(pyenv virtualenv-init -)\"" >> ${HOME}/.bashrc
-	source ${HOME}/.bashrc
     fi
 
     if [ -f ${HOME}/.zshrc ]; then
     	echo "export PATH=\"${HOME}/.pyenv/bin:\$PATH\"" >> ${HOME}/.zshrc
       	echo "eval \"\$(pyenv init -)\"" >> ${HOME}/.zshrc
       	echo "eval \"\$(pyenv virtualenv-init -)\"" >> ${HOME}/.zshrc
-	source ${HOME}/.zshrc
     fi
 
     if [ -d ${HOME}/.config/fish ]; then
 	echo "set -x PATH \"${HOME}/.pyenv/bin\" \$PATH" >> ${HOME}/.config/fish/config.fish
       	echo 'status --is-interactive; and . (pyenv init -|psub)'  >> ${HOME}/.config/fish/config.fish
       	echo 'status --is-interactive; and . (pyenv virtualenv-init -|psub)' >> ${HOME}/.config/fish/config.fish
-	source ${HOME}/.config/fish/config.fish	
     fi
 
     echo "installing Python 3.7"
+    export PATH="${HOME}/.pyenv/bin:$PATH"
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -"
     pyenv install 3.7.3
     pyenv global 3.7.3
 
     cleantmp
-
 elif (whiptail --title "PYTHON" --yesno "Would you like to download and install Python 3.7, IDLE, and the pip package manager?" 8 90) then
     echo "Installing PYTHON"
     createtmp

--- a/pengwin-setup.d/pythonpi.sh
+++ b/pengwin-setup.d/pythonpi.sh
@@ -32,7 +32,7 @@ if (whiptail --title "PYTHON" --yesno "Would you like to download and install Py
     echo "installing Python 3.7"
     export PATH="${HOME}/.pyenv/bin:$PATH"
     eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -"
+    eval "$(pyenv virtualenv-init -)"
     pyenv install 3.7.3
     pyenv global 3.7.3
 


### PR DESCRIPTION
The script has a shebang to ensure it is run with bash and in pengwin-setup the invoke command is directly with bash, so there will be no issues with shell incompatibility and these commands. Sourcing a zsh/fish RC file while in a Bash shell script also wouldn't be a great idea, though why sourcing the .bashrc file within the script doesn't work, I'm not totally sure of? ~I have a feeling it might be an if statement early on in .bashrc stopping it reaching the end of the file, since it's being running within a script vs. being run at shell open/login.~ I was right, at the beginning of .bashrc there is:
`case $- in
    *i*) ;;
      *) return ;;
esac`
In an interactive shell `echo $-` gives some value along lines of himBHs, whereas when run from a script I just get something along the lines of hB.

Though this method won't add pyenv to the path when the user is brought back to their default shell, so perhaps show a warning regarding needing a shell restart?