### PR TITLE
Colortool install improvements

### DIFF
--- a/pengwin-setup.d/colortool.sh
+++ b/pengwin-setup.d/colortool.sh
@@ -77,8 +77,17 @@ case "\$1" in
 		echo "\$SchemeNames"
 		return 0
 		;;
+	-p|--list-previews)
+		"${ColortoolDir}/ColorTool.exe" --xterm --schemes
+		echo ""
+		return 0
+		;;
 	-s|--set-theme)
 		set_theme "\$2"
+		return \$?
+		;;
+	-r|--reset)
+		reset
 		return \$?
 		;;
 	*)
@@ -129,6 +138,25 @@ elif [[ \$result -eq 2 ]] ; then
 	return 1
 else
 	return 0
+fi
+
+}
+
+function reset()
+{
+
+if [[ -f "/etc/profile.d/01-colortool.sh" ]] ; then
+	if sudo rm -f "/etc/profile.d/01-colortool.sh" ; then
+		echo "Reset console theme to default. Please restart shell to see changes"
+		return 0
+	else
+		echo "Failed to get root, unable to remove Pengwin launch config"
+		return 1
+	fi
+else
+	echo "No console scheme configured to be set on Pengwin launch"
+	echo "If your console is currently themed, please restart the shell to return to default"
+	return 1
 fi
 
 }

--- a/pengwin-setup.d/colortool.sh
+++ b/pengwin-setup.d/colortool.sh
@@ -103,7 +103,9 @@ function usage() {
 # Print usage
 echo "Usage: colortool-setup -h|--help"
 echo "                       -l|--list-themes"
+echo "                       -p|--list-previews"
 echo "                       -s|--set-theme "theme_name""
+echo "                       -r|--reset"
 
 }
 

--- a/pengwin-setup.d/colortool.sh
+++ b/pengwin-setup.d/colortool.sh
@@ -90,6 +90,10 @@ case "\$1" in
 		reset
 		return \$?
 		;;
+	-d|--display-current)
+		display_current
+		return \$?
+		;;
 	*)
 		echo "Unrecognised argument[s]. Usage: colortool -h|--help"
 		return 1
@@ -106,6 +110,7 @@ echo "                       -l|--list-themes"
 echo "                       -p|--list-previews"
 echo "                       -s|--set-theme "theme_name""
 echo "                       -r|--reset"
+echo "                       -d|--display-current"
 
 }
 
@@ -158,6 +163,20 @@ if [[ -f "/etc/profile.d/01-colortool.sh" ]] ; then
 else
 	echo "No console scheme configured to be set on Pengwin launch"
 	echo "If your console is currently themed, please restart the shell to return to default"
+	return 1
+fi
+
+}
+
+function display_current()
+{
+
+if [[ -f "/etc/profile.d/01-colortool.sh" ]] ; then
+	local current_theme="\$(cat /etc/profile.d/01-colortool.sh | cut -d\" -f4 | sed 's|.itermcolors||g')"
+	echo "Currently configured to set \"\$current_theme\" on Pengwin launch"
+	return 0
+else
+	echo "No console scheme configured to be set on Pengwin launch"
 	return 1
 fi
 


### PR DESCRIPTION
GitHub seemed to be having issues earlier when I was testing out latest Pengwin development patches, so the downloads kept failing leaving the ColorTool install in a weird half-way state that the user had to deal with.

So now I've added checks in that only allow the script to continue at each point where a download occurs, if the download occurs successfully. While doing this made a few other small changes:
- Updated ColorTool download URL to link to new Apr2019 release
- Added option to display a list of the themes with previews (simply accesses ColorTool.exe --schemes)
- Added option to delete current Pengwin launch config
- Added option to display current Pengwin launch config