### PR TITLE
[HOTFIX] Debian testing fails to upgrade now & code clean up

### DIFF
--- a/pengwin-setup
+++ b/pengwin-setup
@@ -8,34 +8,40 @@ source ${SetupDir}/common.sh "$@"
 
 # define functions
 
-function CheckUpgrades {
-echo "Updating package database"
-sudo apt-get update
+function check_upgrades() {
+  echo "Updating package database"
 
-# Check for .dist-upgrade file in /etc/apt and inform user dist-upgrade available if so
-if [ -f "/etc/apt/.dist-upgrade" ] ; then
-	# whiptail prompt here, delete on dist-upgrade
-	echo "Distribution upgrade flag noticed! Alerting user"
-	if (whiptail --title "Upgrade Available" --yesno "A distribution upgrade is available. In addition to regular package upgrades, this may also install / remove packages. Would you like to continue?\n\nTo run a non-automated distribution upgrade and see package changes, or to perform this in your own time, run 'sudo apt-get dist-upgrade'" 12 90) then
-		sudo rm /etc/apt/.dist-upgrade
-		sudo apt-get dist-upgrade -y
-		exit 0
-	fi
-fi
+  local debian_security_ok="$(cat /etc/apt/sources.list 2>&1 | grep -c "https://deb.debian.org/debian-security testing/updates")"
+  if [[ ${debian_security_ok} != 0 ]] ; then
+    sudo sed -i 's$debian-security testing/updates$debian-security testing-security$g' /etc/apt/sources.list
+  fi
 
-# Check if there's any upgrades to pengwin-setup / pengwin-base
-echo "Running upgrade check..."
-UPGRD_CHECK="$(sudo apt-get upgrade --show-upgraded --assume-no | grep pengwin)"
-if [[ "${UPGRD_CHECK}" == *"pengwin"* ]] ; then
-	echo "Pengwin core package upgrades found"
-	if (whiptail --title "Upgrades Available" --yesno "Updates have been detected for Pengwin core packages. Would you like to update them? This is highly recommended. Note: Pengwin-setup will close after installation complete." 10 91) then
+  sudo apt-get update --allow-releaseinfo-change
 
-	  # Ensure that packages get updated without affecting other held packages like udev
-    		sudo apt-mark unhold pengwin-base pengwin-setup > /dev/null 2>&1
-		sudo apt-get upgrade pengwin-base pengwin-setup -y
-		exit 0
-	fi
-fi
+  # Check for .dist-upgrade file in /etc/apt and inform user dist-upgrade available if so
+  if [[ -f "/etc/apt/.dist-upgrade" ]] ; then
+    # whiptail prompt here, delete on dist-upgrade
+    echo "Distribution upgrade flag noticed! Alerting user"
+    if (whiptail --title "Upgrade Available" --yesno "A distribution upgrade is available. In addition to regular package upgrades, this may also install / remove packages. Would you like to continue?\n\nTo run a non-automated distribution upgrade and see package changes, or to perform this in your own time, run 'sudo apt-get dist-upgrade'" 12 90) ; then
+      sudo rm /etc/apt/.dist-upgrade
+      sudo apt-get dist-upgrade -y
+      exit 0
+    fi
+  fi
+
+  # Check if there's any upgrades to pengwin-setup / pengwin-base
+  echo "Running upgrade check..."
+  local upgrd_check="$(sudo apt-get upgrade --show-upgraded --assume-no | grep pengwin)"
+  if [[ "${upgrd_check}" == *"pengwin"* ]] ; then
+    echo "Pengwin core package upgrades found"
+    if (whiptail --title "Upgrades Available" --yesno "Updates have been detected for Pengwin core packages. Would you like to update them? This is highly recommended. Note: Pengwin-setup will close after installation complete." 10 91) ; then
+
+      # Ensure that packages get updated without affecting other held packages like udev
+      sudo apt-mark unhold pengwin-base pengwin-setup > /dev/null 2>&1
+      sudo apt-get upgrade pengwin-base pengwin-setup -y
+      exit 0
+    fi
+  fi
 }
 
 function WelcomePrompt {
@@ -143,7 +149,7 @@ WelcomePrompt
 continue_prompt
 
 if [[ ! ${SKIP_UPDATES} ]]; then
-  CheckUpgrades
+  check_upgrades
 fi
 
 # Ensure our packages are held to prevent odd situation of


### PR DESCRIPTION
I made some indentation and code clean up which messes the diff, but the real change was:

```
  local debian_security_ok="$(cat /etc/apt/sources.list 2>&1 | grep -c "https://deb.debian.org/debian-security testing/updates")"
  if [[ ${debian_security_ok} != 0 ]] ; then
    sudo sed -i 's$debian-security testing/updates$debian-security testing-security$g' /etc/apt/sources.list
  fi

  sudo apt-get update --allow-releaseinfo-change

```