### PR TITLE
add command_check to common.sh

### DIFF
--- a/pengwin-setup.d/cloudcli.sh
+++ b/pengwin-setup.d/cloudcli.sh
@@ -74,8 +74,7 @@ function install_doctl() {
     createtmp
 
     echo "Checking for go"
-    if ! go version ; then
-    if ! /usr/local/go/bin/go version ; then
+    if ! command_check '/usr/local/go/bin/go' 'version' ; then
       echo "Downloading Go using wget."
       wget -c "https://dl.google.com/go/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz"
       tar -xzf go*.tar.gz
@@ -86,7 +85,6 @@ function install_doctl() {
       # makes sure to set correct env variables
       export GOROOT=/usr/local/go
       export PATH="${GOROOT}/bin:$PATH"
-    fi
     fi
 
     mkdir gohome

--- a/pengwin-setup.d/cloudcli.sh
+++ b/pengwin-setup.d/cloudcli.sh
@@ -74,17 +74,21 @@ function install_doctl() {
     createtmp
 
     echo "Checking for go"
-    if ! command_check '/usr/local/go/bin/go' 'version' ; then
+    command_check '/usr/local/go/bin/go' 'version'
+    local go_check=$?
+    if [ $go_check -eq 1 ] ; then
       echo "Downloading Go using wget."
       wget -c "https://dl.google.com/go/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz"
       tar -xzf go*.tar.gz
       export GOROOT=$(pwd)/go
       export PATH="${GOROOT}/bin:$PATH"
     else
-      # Whether it was just installed previously, or right now,
-      # makes sure to set correct env variables
-      export GOROOT=/usr/local/go
-      export PATH="${GOROOT}/bin:$PATH"
+      if [ $go_check -eq 2 ] ; then
+        # If go was only just installed previously without shell reset,
+        # makes sure to set correct env variables
+        export GOROOT=/usr/local/go
+        export PATH="${GOROOT}/bin:$PATH"
+      fi
     fi
 
     mkdir gohome

--- a/pengwin-setup.d/common.sh
+++ b/pengwin-setup.d/common.sh
@@ -53,12 +53,12 @@ sudo apt-get autoremove -y
 }
 
 function command_check() {
-# Usage: command_check <EXPECTED PATH>
+# Usage: command_check <EXPECTED PATH> <ARGS (if any)>
 local execname=$(echo "$1" | sed -e "s|^.*\/||g")
-if "$execname" > /dev/null 2>&1 ; then
+if "$execname" "$2" > /dev/null 2>&1 ; then
 	echo "Executable $execname in PATH"
 	return 0
-elif "$1" > /dev/null 2>&1 ; then
+elif "$1" "$2" > /dev/null 2>&1 ; then
 	echo "Executable '$execname' at: $1"
 	return 0
 else

--- a/pengwin-setup.d/common.sh
+++ b/pengwin-setup.d/common.sh
@@ -53,18 +53,18 @@ sudo apt-get autoremove -y
 }
 
 function command_check() {
-# Usage: command_check <EXPECTED PATH> <ARGS (if any)>
-local execname=$(echo "$1" | sed -e "s|^.*\/||g")
-if "$execname" "$2" > /dev/null 2>&1 ; then
-	echo "Executable $execname in PATH"
-	return 0
-elif "$1" "$2" > /dev/null 2>&1 ; then
-	echo "Executable '$execname' at: $1"
-	return 0
-else
-	echo "Executable '$execname' not found"
-	return 1
-fi
+  # Usage: command_check <EXPECTED PATH> <ARGS (if any)>
+  local execname=$(echo "$1" | sed -e "s|^.*\/||g")
+  if ("$execname" "$2") > /dev/null 2>&1 ; then
+    echo "Executable $execname in PATH"
+    return 0
+  elif ("$1" "$2") > /dev/null 2>&1 ; then
+    echo "Executable '$execname' at: $1"
+    return 2
+  else
+    echo "Executable '$execname' not found"
+    return 1
+  fi
 }
 
 #function getexecname {

--- a/pengwin-setup.d/common.sh
+++ b/pengwin-setup.d/common.sh
@@ -52,6 +52,21 @@ echo "Removing unnecessary packages."
 sudo apt-get autoremove -y
 }
 
+function command_check() {
+# Usage: command_check <EXPECTED PATH>
+local execname=$(echo "$1" | sed -e "s|^.*\/||g")
+if "$execname" > /dev/null 2>&1 ; then
+	echo "Executable $execname in PATH"
+	return 0
+elif "$1" > /dev/null 2>&1 ; then
+	echo "Executable '$execname' at: $1"
+	return 0
+else
+	echo "Executable '$execname' not found"
+	return 1
+fi
+}
+
 #function getexecname {
 #user_path=$(cmd-exe /c "echo %HOMEDRIVE%%HOMEPATH%" | tr -d "\r")
 #wslexec_dir=$(echo $PATH | sed -e 's/:/\n/g' | grep 'Program\ Files/WindowsApps')

--- a/pengwin-setup.d/docker.sh
+++ b/pengwin-setup.d/docker.sh
@@ -18,7 +18,9 @@ function docker_install_build_relay() {
   if [[ ! -f "${wHome}/.npiperelay/npiperelay.exe" ]]; then
 
     echo "Checking for go"
-    if ! command_check '/usr/local/go/bin/go' 'version' ; then
+    command_check '/usr/local/go/bin/go' 'version'
+    local go_check=$?
+    if [ $go_check -eq 1 ] ; then
       echo "Downloading Go using wget."
       wget -c "https://dl.google.com/go/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz"
       tar -xzf go*.tar.gz
@@ -26,10 +28,12 @@ function docker_install_build_relay() {
       export GOROOT=$(pwd)/go
       export PATH="${GOROOT}/bin:$PATH"
     else
-      # Whether it was just installed previously, or right now,
-      # makes sure to set correct env variables
-      export GOROOT=/usr/local/go
-      export PATH="${GOROOT}/bin:$PATH"
+      if [ $go_check -eq 2 ] ; then
+        # If go was only just installed previously without shell reset,
+        # makes sure to set correct env variables
+        export GOROOT=/usr/local/go
+        export PATH="${GOROOT}/bin:$PATH"
+      fi
     fi
 
     mkdir gohome

--- a/pengwin-setup.d/docker.sh
+++ b/pengwin-setup.d/docker.sh
@@ -18,12 +18,17 @@ function docker_install_build_relay() {
   if [[ ! -f "${wHome}/.npiperelay/npiperelay.exe" ]]; then
 
     echo "Checking for go"
-    if ! (go version); then
+    if ! command_check '/usr/local/go/bin/go' 'version' ; then
       echo "Downloading Go using wget."
       wget -c "https://dl.google.com/go/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz"
       tar -xzf go*.tar.gz
 
       export GOROOT=$(pwd)/go
+      export PATH="${GOROOT}/bin:$PATH"
+    else
+      # Whether it was just installed previously, or right now,
+      # makes sure to set correct env variables
+      export GOROOT=/usr/local/go
       export PATH="${GOROOT}/bin:$PATH"
     fi
 

--- a/pengwin-setup.d/ruby.sh
+++ b/pengwin-setup.d/ruby.sh
@@ -52,8 +52,7 @@ if (whiptail --title "RAILS" --yesno "Would you like to download and install Rai
   echo "Installing RAILS"
 
   echo "Checking for node"
-  if ! node -v ; then
-  if ! "$HOME/n/bin/node" -v ; then # double checks if our local nodejs install was just performed but PATH not yet updated
+  if ! command_check "$HOME/n/bin/node" "-v" ; then # double checks if our local nodejs install was just performed but PATH not yet updated
     echo "node not installed. Offering user nodejs install"
     if (whiptail --title "NODE" --yesno "Ruby on Rails framework requires JavaScript Runtime Environment (Node.js) to manage the features of Rails.\n\nWould you like to download and install NodeJS using n and the npm package manager?" 12 65); then
       bash ${SetupDir}/nodejs.sh -y "$@"
@@ -61,7 +60,6 @@ if (whiptail --title "RAILS" --yesno "Would you like to download and install Rai
       echo "Skipping RAILS"
       exit 1
     fi
-  fi
   fi
   echo "node installed"
 

--- a/pengwin-setup.d/ruby.sh
+++ b/pengwin-setup.d/ruby.sh
@@ -52,7 +52,9 @@ if (whiptail --title "RAILS" --yesno "Would you like to download and install Rai
   echo "Installing RAILS"
 
   echo "Checking for node"
-  if ! command_check "$HOME/n/bin/node" "-v" ; then # double checks if our local nodejs install was just performed but PATH not yet updated
+  command_check "$HOME/n/bin/node" "-v"
+  node_check=$?
+  if [ $node_check -eq 1 ] ; then # double checks if our local nodejs install was just performed but PATH not yet updated
     echo "node not installed. Offering user nodejs install"
     if (whiptail --title "NODE" --yesno "Ruby on Rails framework requires JavaScript Runtime Environment (Node.js) to manage the features of Rails.\n\nWould you like to download and install NodeJS using n and the npm package manager?" 12 65); then
       bash ${SetupDir}/nodejs.sh -y "$@"


### PR DESCRIPTION
Provides an alternative method of checking for previous installs (e.g. go or nodejs) by looking both in PATH, and at the expected location. Have converted the cloudcli doclt, docker and ruby scripts to use this new function