### PR TITLE
add nvm option to nodejs install

### DIFF
--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -13,10 +13,21 @@ if [[ ! ${SkipConfirmations} ]]; then
   fi
 fi
 
+echo "Offering user n / nvm version manager choice"
+menu_choice=$(
+
+  menu --title "nodejs" --radiolist "Choose Node.js version manager\n[SPACE to select, ENTER to confirm]:" 10 85 2 \
+    "N" "n version manager" off \
+    "NVM" "nvm version manager" off \
+
+    3>&1 1>&2 2>&3)
+
+if [[ ${menu_choice} == "CANCELLED" ]] ; then
+  exit 1
+fi
+
 createtmp
-
 echo "Look for Windows version of npm"
-
 NPM_WIN_PROFILE="/etc/profile.d/rm-win-npm-path.sh"
 NPM_PROFILE="/etc/profile.d/n-prefix.sh"
 
@@ -52,18 +63,7 @@ EOF
 
 fi
 
-echo "Offering user n / nvm version manager choice"
-menu_choice=$(
-
-  menu --title "nodejs" --radiolist "Choose Node.js version manager\n[SPACE to select, ENTER to confirm]:" 10 85 2 \
-    "N" "n version manager" off \
-    "NVM" "nvm version manager" off \
-
-    3>&1 1>&2 2>&3)
-
-if [[ ${menu_choice} == "CANCELLED" ]] ; then
-  exit 1
-elif [[ ${menu_choice} == "N" ]] ; then
+if [[ ${menu_choice} == "N" ]] ; then
   echo "Ensuring we have build-essential installed"
   sudo apt-get -y -q install build-essential
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -109,10 +109,10 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   printf '%s' "$filecontents" > "$HOME/.bashrc"
 
   # Add nvm to path, nvm to bash completion
-  echo '$NVM_PATH' | sudo tee /etc/profile.d/nvm-prefix.sh
-  echo '$NVM_SH' | sudo tee -a /etc/profile.d/nvm-prefix.sh
+  echo "$NVM_PATH" | sudo tee /etc/profile.d/nvm-prefix.sh
+  echo "$NVM_SH" | sudo tee -a /etc/profile.d/nvm-prefix.sh
   sudo mkdir -p /etc/bash_completion.d
-  echo '$NVM_COMP' | sudo tee /etc/bash_completion.d/nvm
+  echo "$NVM_COMP" | sudo tee /etc/bash_completion.d/nvm
 
   # Add the path for sudo
   #SUDO_PATH="$(sudo cat /etc/sudoers | grep "secure_path" | sed "s/\(^.*secure_path=\"\)\(.*\)\(\"\)/\2/")"

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -72,9 +72,12 @@ elif [[ ${menu_choice} == "N" ]] ; then
   env SHELL="$(which bash)" bash  n-install.sh -y #Force the installation to bash
 
   N_PATH="$(cat ${HOME}/.bashrc | grep "^.*N_PREFIX.*$" | cut -d'#' -f 1)"
-
   echo "${N_PATH}" | sudo tee "${NPM_PROFILE}"
   eval "${N_PATH}"
+
+  # Clear N from .bashrc now not needed
+  filecontents=$(cat "$HOME/.bashrc" | grep -v -e '^.*N_PREFIX.*$')
+  printf '%s' "$filecontents" > "$HOME/.bashrc"
 
   # Add the path for sudo
   SUDO_PATH="$(sudo cat /etc/sudoers | grep "secure_path" | sed "s/\(^.*secure_path=\"\)\(.*\)\(\"\)/\2/")"
@@ -100,6 +103,10 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   NVM_COMP="$(cat ${HOME}/.bashrc | grep '^.*$NVM_DIR/bash_completion.*$')"
   eval "$NVM_PATH"
   eval "$NVM_SH"
+
+  # Clear nvm from .bashrc now not needed
+  filecontents=$(cat "$HOME/.bashrc" | grep -v -e '^.*NVM_DIR.*$')
+  printf '%s' "$filecontents" > "$HOME/.bashrc"
 
   # Add nvm to path, nvm to bash completion
   echo '$NVM_PATH' | sudo tee /etc/profile.d/nvm-prefix.sh

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -8,7 +8,6 @@ if [[ ! ${SkipConfirmations} ]]; then
     echo "Installing NODE"
   else
     echo "Skipping NODE"
-
     exit 1
   fi
 fi
@@ -23,6 +22,7 @@ menu_choice=$(
     3>&1 1>&2 2>&3)
 
 if [[ ${menu_choice} == "CANCELLED" ]] ; then
+  echo "Skipping NODE"
   exit 1
 fi
 
@@ -34,12 +34,9 @@ NPM_PROFILE="/etc/profile.d/n-prefix.sh"
 if [[ "$(which npm)" == $(wslpath 'C:\')* ]]; then
 
   if ! (confirm --title "npm in Windows" --yesno "npm is already installed in Windows in \"$(wslpath -m "$(which npm)")\".\n\nWould you still want to install the Linux version? This will hide the Windows version inside Pengwin." 12 80); then
-
     echo "Skipping NODE"
-
     exit 1
   fi
-
 
   sudo tee "${NPM_WIN_PROFILE}" << EOF
 
@@ -60,7 +57,6 @@ fi
 EOF
 
   eval "$(cat "${NPM_WIN_PROFILE}")"
-
 fi
 
 if [[ ${menu_choice} == "N" ]] ; then

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -74,7 +74,6 @@ elif [[ ${menu_choice} == "N" ]] ; then
   N_PATH="$(cat ${HOME}/.bashrc | grep "^.*N_PREFIX.*$" | cut -d'#' -f 1)"
 
   echo "${N_PATH}" | sudo tee "${NPM_PROFILE}"
-
   eval "${N_PATH}"
 
   # Add the path for sudo
@@ -103,10 +102,10 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   eval "$NVM_SH"
 
   # Add nvm to path, nvm to bash completion
-  sudo bash -c "echo '$NVM_PATH' > /etc/profile.d/nvm-prefix.sh"
-  sudo bash -c "echo '$NVM_SH' >> /etc/profile.d/nvm-prefix.sh"
+  echo '$NVM_PATH' | sudo tee /etc/profile.d/nvm-prefix.sh
+  echo '$NVM_SH' | sudo tee -a /etc/profile.d/nvm-prefix.sh
   sudo mkdir -p /etc/bash_completion.d
-  sudo bash -c "echo '$NVM_COMP' > /etc/bash_completion.d/nvm"
+  echo '$NVM_COMP' | sudo tee /etc/bash_completion.d/nvm
 
   # Add the path for sudo
   #SUDO_PATH="$(sudo cat /etc/sudoers | grep "secure_path" | sed "s/\(^.*secure_path=\"\)\(.*\)\(\"\)/\2/")"

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -4,7 +4,7 @@ source $(dirname "$0")/common.sh "$@"
 
 if [[ ! ${SkipConfirmations} ]]; then
 
-  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js with npm using either the n or nvm version manager?" 8 88); then
+  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js (with npm) using either the n or nvm version manager?" 8 88); then
     echo "Installing NODE"
   else
     echo "Skipping NODE"
@@ -55,9 +55,9 @@ fi
 echo "Offering user n / nvm version manager choice"
 menu_choice=$(
 
-  menu --title "nodejs" --radiolist "Choose Node.js version manager\n[SPACE to select, ENTER to confirm]:" 16 95 10 \
-    "N" "'n' Node.js version manager" off \
-    "NVM" "'nvm' Node.js version manager" off \
+  menu --title "nodejs" --radiolist "Choose Node.js version manager\n[SPACE to select, ENTER to confirm]:" 10 85 2 \
+    "N" "n version manager" off \
+    "NVM" "nvm version manager" off \
 
     3>&1 1>&2 2>&3)
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -91,7 +91,8 @@ elif [[ ${menu_choice} == "N" ]] ; then
   installed=0
 elif [[ ${menu_choice} == "NVM" ]] ; then
   echo "Installing nvm, Node.js version manager"
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+  temp_profile="$(pwd)/temp_profile"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | PROFILE="$temp_profile" bash
 
   # Set NVM_DIR variable and load nvm
   NVM_PATH="$(cat ${HOME}/.bashrc | grep '^export NVM_DIR=')"
@@ -99,6 +100,7 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   eval "$NVM_PATH"
   eval "$NVM_SH"
 
+  sudo mv "$temp_profile" "/etc/profile.d/nvm-prefix.sh"
   # Add the path for sudo
   #SUDO_PATH="$(sudo cat /etc/sudoers | grep "secure_path" | sed "s/\(^.*secure_path=\"\)\(.*\)\(\"\)/\2/")"
   #echo "Defaults secure_path=\"${SUDO_PATH}:${NVM_DIR}/bin\"" | sudo EDITOR='tee ' visudo --quiet --file=/etc/sudoers.d/npm-path

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -3,7 +3,7 @@
 source $(dirname "$0")/uninstall-common.sh
 
 yarn_key='72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310'
-line_rgx='^[^#]*\bN_PREFIX='
+n_line_rgx='^[^#]*\bN_PREFIX='
 
 function main()
 {
@@ -22,20 +22,21 @@ fi
 
 rem_dir "$HOME/n"
 rem_dir "$HOME/.npm"
+rem_dir "$HOME/.nvm"
 
 echo "Removing PATH modifier(s)..."
 sudo_rem_file "/etc/profile.d/n-prefix.sh"
+sudo_rem_file "/etc/profile.d/nvm-prefix.sh"
+sudo_rem_file "/etc/profile.d/rm-win-npm-path.sh"
+# The .bashrc path clean shouldn't be needed on newer installs, but takes into account legacy pengwin-setup nodejs installs
 if [[ -f "$HOME/.bashrc" ]] ; then
 	echo "$HOME/.bashrc found, cleaning"
-	clean_file "$HOME/.bashrc" "$line_rgx"
-fi
-if [[ -f "$HOME/.zshrc" ]] ; then
-	echo "$HOME/.zshrc found, cleaning"
-	clean_file "$HOME/.zshrc" "$line_rgx"
+	clean_file "$HOME/.bashrc" "$n_line_rgx"
 fi
 
 echo "Removing bash completion..."
 sudo_rem_file "/etc/bash_completion.d/npm"
+sudo_rem_file "/etc/bash_completion.d/nvm"
 
 remove_package "yarn"
 


### PR DESCRIPTION
Adds user choice for either n or nvm Node.js version manager installs and updates nodejs uninstaller accordingly. Also updates the n version manager install to remove the redundant n environment modifications to .bashrc after we've added them to /etc/profile.d/n-prefix.sh

I haven't added nvm to the sudoers file yet, even after our conversation on Teams the other day, as:
1) i'm not a fan of the security implications of giving sudo privileges to nvm when it's still a user owned and user modifiable command
2) i'm not 100% sure if this will even work as 'nvm' is actually a function that gets loaded into the shell environment, as opposed to an executable called from path

If i'm wrong however, then I've got the code in place it will just need modifying slightly and uncommenting to make this change.