### PR TITLE
#271 [Pengwin-271] Switch path written to installservice.bat (part of Cassandra implementation) from Linux format to Windows format

### DIFF
--- a/pengwin-setup.d/cassandra.sh
+++ b/pengwin-setup.d/cassandra.sh
@@ -1,97 +1,122 @@
 #!/bin/bash
 
-source $(dirname "$0")/common.sh "$@"
+# shellcheck disable=SC1090
+source "$(dirname "$0")/common.sh" "$@"
+declare wHome
+declare USER
 
-if (whiptail --title "CASSANDRA" --yesno "Would you like to download and install Apache Cassandra?" 8 60) then
+function main() {
+
+  if (confirm --title "CASSANDRA" --yesno "Would you like to download and install Apache Cassandra?" 8 60); then
+
     echo "Installing CASSANDRA"
     createtmp
     curl https://dist.apache.org/repos/dist/release/cassandra/KEYS | gpg --dearmor > cassandra.gpg
     sudo cp cassandra.gpg /etc/apt/trusted.gpg.d/cassandra.gpg
     sudo chmod 644 /etc/apt/trusted.gpg.d/cassandra.gpg
     sudo bash -c "echo 'deb http://www.apache.org/dist/cassandra/debian 311x main' > /etc/apt/sources.list.d/cassandra.list"
-    sudo apt-get update
-    sudo su -c "echo '${USER} ALL=(root) NOPASSWD: /bin/mount, /bin/umount' >> /etc/sudoers"
-    sudo mount -t proc proc /proc
-    sudo apt-get install cassandra -y
-    sudo su -c "echo 'cassandra ALL=(root) NOPASSWD: /bin/mount, /bin/umount' >> /etc/sudoers"
-    sudo su -c "echo 'sudo mount -t proc proc /proc' >> /etc/profile"
+    sudo apt-get -y -q update
+
+    local mountProc="/usr/bin/mount-proc"
+    sudo tee "${mountProc}" << EOF
+#!/bin/bash
+
+mount -t proc proc /proc
+
+EOF
+
+    sudo chmod 700 "${mountProc}"
+
+    echo "%sudo   ALL=NOPASSWD: ${mountProc}" | sudo EDITOR='tee -a' visudo --quiet --file=/etc/sudoers.d/mount-proc
+
+    local startCassandra="/usr/bin/start-cassandra"
+    sudo tee "${startCassandra}" << EOF
+#!/bin/bash
+
+sudo -Su cassandra /usr/sbin/cassandra -f
+
+EOF
+
+    sudo chmod 700 "${startCassandra}"
+
+    echo "%sudo   ALL=NOPASSWD: ${startCassandra}" | sudo EDITOR='tee -a' visudo --quiet --file=/etc/sudoers.d/start-cassandra
+
+    local profile_mountproc="/etc/profile.d/mount-proc.sh"
+    sudo tee "${profile_mountproc}" << EOF
+#!/bin/bash
+
+# Check if we have Windows Path
+if ( which cmd.exe >/dev/null ); then
+
+  sudo ${mountProc}
+fi
+
+EOF
+
+    sudo "${mountProc}"
+    sudo apt-get -y -q install cassandra
 
     whiptail --title "CASSANDRA" --msgbox "Cassandra must be run as user cassandra, $ sudo -u cassandra /usr/sbin/cassandra -f " 8 90
 
-    if (whiptail --title "CASSANDRA" --yesno "Would you like to store Cassandra configuration and logs in your Windows user home folder?" 8 95) then
+    if (whiptail --title "CASSANDRA" --yesno "Would you like to store Cassandra configuration and logs in your Windows user home folder?" 8 95) ; then
 
-        if [ -d "${wHome}/cassandra" ]; then
-            echo "Backing up existing Cassandra directony"
-            sudo cp -r "${wHome}/cassandra" "${wHome}/cassandra.old"
-        fi
+      if [[ -d "${wHome}/cassandra" ]]; then
+        echo "Backing up existing Cassandra directony"
+        sudo cp -r "${wHome}/cassandra" "${wHome}/cassandra.old"
+      fi
 
-        echo "Moving Cassandra configuration directory"
-        sudo unlink /etc/cassandra # these clean up from previous installs
-        sudo mkdir /etc/cassandra
-        sudo cp -r /etc/cassandra/ "${wHome}"
-        sudo rm -r /etc/cassandra
-        sudo ln -s "${wHome}/cassandra" /etc/cassandra
+      echo "Moving Cassandra configuration directory"
+      sudo unlink /etc/cassandra # these clean up from previous installs
+      sudo mkdir /etc/cassandra
+      sudo cp -r /etc/cassandra/ "${wHome}"
+      sudo rm -r /etc/cassandra
+      sudo ln -s "${wHome}/cassandra" /etc/cassandra
 
-        echo "Moving Cassandra log directory"
-        sudo mkdir "${wHome}/cassandra/logs"
-        sudo rm -r /var/log/cassandra
-        sudo ln -s "${wHome}/cassandra/logs" /var/log/cassandra
+      echo "Moving Cassandra log directory"
+      sudo mkdir "${wHome}/cassandra/logs"
+      sudo rm -r /var/log/cassandra
+      sudo ln -s "${wHome}/cassandra/logs" /var/log/cassandra
 
-        echo "Setting permissions"
-        sudo chown -R cassandra:cassandra /etc/cassandra
-        sudo chown -R cassandra:cassandra /var/lib/cassandra/
-        sudo chown -R cassandra:cassandra /var/log/cassandra/
+      echo "Setting permissions"
+      sudo chown -R cassandra:cassandra /etc/cassandra
+      sudo chown -R cassandra:cassandra /var/lib/cassandra/
+      sudo chown -R cassandra:cassandra /var/log/cassandra/
     fi
 
-    if (whiptail --title "CASSANDRA" --yesno "Would you like to create .bat files to run and update Cassandra in your Windows user home folder?" 8 102) then
+    if (whiptail --title "CASSANDRA" --yesno "Would you like to create .bat files to run Cassandra in your Windows user home folder?" 8 102) ; then
 
-        echo "Enter your UNIX password below."
-        passvar=0
-        read -s -p "[sudo] password for $USER: " passvar
-        until (echo $sudo_pwd | sudo -S echo '' 2>/dev/null)
-        do
-            echo -e '\nSorry, try again.'
-            read -s -p "[sudo] password for $USER: " passvar
-        done
+      sudo mkdir "${wHome}/cassandra/" # in case user opted to keep config on WSL
 
-        sudo mkdir "${wHome}/cassandra/" # in case user opted to keep config on WSL
-
-        echo "Creating autorun.bat file in home folder"
-        phrase1='wlinux.exe run "echo '
-        phrase2=" | sudo -Su root mount -t proc proc /proc"
-        phrase3=" | sudo -Su cassandra /usr/sbin/cassandra -f"
-        write1="$phrase1$passvar$phrase2"
-        write2="$phrase1$passvar$phrase3"
-        cat << EOF > autorun.bat
+      echo "Creating autorun.bat file in home folder"
+      local phrase1='pengwin.exe run " '
+      local phrase2=" sudo ${mountProc}"
+      local phrase3=" sudo ${startCassandra}"
+      local write1="${phrase1}${phrase2}"
+      local write2="${phrase1}${phrase3}"
+      cat << EOF > autorun.bat
 @echo off
-$write1"
-$write2"
+${write1}"
+${write2}"
 EOF
-        sudo cp autorun.bat "${wHome}/cassandra/"
-        echo "Creating update.bat file on Windows Desktop"
-        phrase1='wlinux.exe run "echo '
-        phrase2=' | sudo -S apt-get update ; sudo -S apt-get upgrade -y ; sudo -S apt-get autoclean -y"'
-====
-        
-        sudo cat << EOF > update.bat
-@echo off
-$write
-EOF
-        sudo cp update.bat "${wHome}/cassandra/"
+      sudo cp autorun.bat "${wHome}/cassandra/"
 
-        echo "Creating installservice .bat file on Windows Desktop"
-        phrase1='sc create NewService binpath= '
-        phrase2='/cassandra/autorun.bat type= share start= auto displayname= Cassandra'
-        write="$phrase1${wHome}$phrase2"
-        sudo cat << EOF > installservice.bat
+      echo "Creating installservice.bat file on Windows Desktop"
+      phrase1='sc create NewService binpath= '
+      phrase2='\cassandra\autorun.bat type= share start= auto displayname= Cassandra'
+      write="$phrase1${wHomeWinPath}$phrase2"
+      sudo cat << EOF > installservice.bat
 @echo off
-$write
+${write}
 EOF
-        sudo cp installservice.bat "${wHome}/cassandra/"
+      sudo cp installservice.bat "${wHome}/cassandra/"
 
     fi
 
     cleantmp
-else
+  else
     echo "Skipping CASSANDRA"
-fi
+  fi
+
+}
+
+main

--- a/pengwin-setup.d/cassandra.sh
+++ b/pengwin-setup.d/cassandra.sh
@@ -3,6 +3,7 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")/common.sh" "$@"
 declare wHome
+declare wHomeWinPath
 declare USER
 
 function main() {


### PR DESCRIPTION
I made the changes not only to use a Windows path but to make it work. This option didn't work since 1.2. I think that probably this is not used for many users, or users start it up by hand.

Anyway, even though the service is correctly installed with a correct path, it complains that the executable didn't respond to start or control request. 

Please check it.