### PR TITLE
add APT managed node.js install options

### DIFF
--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -16,10 +16,10 @@ echo "Offering user n / nvm version manager choice"
 menu_choice=$(
 
   menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 85 4 \
-    "N" "install with n version manager (NOT fish shell compatible)" off \
-    "NVM" "install with nvm version manager (NOT fish shell compatible)" off \
-    "LATEST" "install latest version via APT package manager" off \
-    "LTS" "install LTS version via APT package manager" off \
+    "N" "Install with n version manager (NOT fish shell compatible)" off \
+    "NVM" "Install with nvm version manager (NOT fish shell compatible)" off \
+    "LATEST" "Install latest version via APT package manager" off \
+    "LTS" "Install LTS version via APT package manager" off \
 
     3>&1 1>&2 2>&3)
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -4,7 +4,7 @@ source $(dirname "$0")/common.sh "$@"
 
 if [[ ! ${SkipConfirmations} ]]; then
 
-  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js (with npm)?" 8 88); then
+  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js (with npm)?" 8 65); then
     echo "Installing NODE"
   else
     echo "Skipping NODE"

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -4,7 +4,7 @@ source $(dirname "$0")/common.sh "$@"
 
 if [[ ! ${SkipConfirmations} ]]; then
 
-  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js (with npm) using either the n or nvm version manager?" 8 88); then
+  if (whiptail --title "NODE" --yesno "Would you like to download and install Node.js (with npm)?" 8 88); then
     echo "Installing NODE"
   else
     echo "Skipping NODE"
@@ -15,9 +15,11 @@ fi
 echo "Offering user n / nvm version manager choice"
 menu_choice=$(
 
-  menu --title "nodejs" --radiolist "Choose Node.js version manager\n[SPACE to select, ENTER to confirm]:" 10 45 2 \
-    "N" "n version manager" off \
-    "NVM" "nvm version manager" off \
+  menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 75 4 \
+    "N" "install with n version manager" off \
+    "NVM" "install with nvm version manager" off \
+    "LATEST" "install latest version via APT package manager" off \
+    "LTS" "install latest LTS version via APT package manager" off \
 
     3>&1 1>&2 2>&3)
 
@@ -126,6 +128,17 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
 
   # Add npm to bash completion
   npm completion | sudo tee /etc/bash_completion.d/npm
+elif [[ ${menu_choice} == "LATEST" ]] ; then
+  echo "Installing latest node.js version from NodeSource repository"
+
+  NODESRC_URL='https://deb.nodesource.com/setup_12.x'
+  curl -sL "$NODESRC_URL" -o repo-install.sh
+  sudo bash repo-install.sh
+
+  sudo apt-get install nodejs
+elif [[ ${menu_choice} == "LTS" ]] ; then
+  echo "Installing LTS node.js version from standard Debian repository"
+  sudo apt-get install nodejs
 fi
 cleantmp
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -15,11 +15,11 @@ fi
 echo "Offering user n / nvm version manager choice"
 menu_choice=$(
 
-  menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 75 4 \
-    "N" "install with n version manager" off \
-    "NVM" "install with nvm version manager" off \
+  menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 85 4 \
+    "N" "install with n version manager (NOT fish shell compatible)" off \
+    "NVM" "install with nvm version manager (NOT fish shell compatible)" off \
     "LATEST" "install latest version via APT package manager" off \
-    "LTS" "install latest LTS version via APT package manager" off \
+    "LTS" "install LTS version via APT package manager" off \
 
     3>&1 1>&2 2>&3)
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -137,13 +137,13 @@ elif [[ ${menu_choice} == "LATEST" ]] ; then
 
   major_vers=12
   version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
-  sudo apt-get install nodejs=$version
+  sudo apt-get install -y -q nodejs=$version
 elif [[ ${menu_choice} == "LTS" ]] ; then
   echo "Installing LTS node.js version from standard Debian repository"
 
   major_vers=10
   version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
-  sudo apt-get install nodejs=$version
+  sudo apt-get install -y -q npm nodejs=$version
 fi
 cleantmp
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -135,10 +135,15 @@ elif [[ ${menu_choice} == "LATEST" ]] ; then
   curl -sL "$NODESRC_URL" -o repo-install.sh
   sudo bash repo-install.sh
 
-  sudo apt-get install nodejs
+  major_vers=12
+  version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
+  sudo apt-get install nodejs=$version
 elif [[ ${menu_choice} == "LTS" ]] ; then
   echo "Installing LTS node.js version from standard Debian repository"
-  sudo apt-get install nodejs
+
+  major_vers=10
+  version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
+  sudo apt-get install nodejs=$version
 fi
 cleantmp
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -131,19 +131,23 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
 elif [[ ${menu_choice} == "LATEST" ]] ; then
   echo "Installing latest node.js version from NodeSource repository"
 
-  NODESRC_URL='https://deb.nodesource.com/setup_12.x'
-  curl -sL "$NODESRC_URL" -o repo-install.sh
+  major_vers=12
+  nodesrc_url="https://deb.nodesource.com/setup_$major_vers.x"
+  curl -sL "$nodesrc_url" -o repo-install.sh
   sudo bash repo-install.sh
 
-  major_vers=12
-  version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
+  version=$(apt-cache madison nodejs | grep 'nodesource' | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
   sudo apt-get install -y -q nodejs=$version
 elif [[ ${menu_choice} == "LTS" ]] ; then
-  echo "Installing LTS node.js version from standard Debian repository"
+  echo "Installing LTS node.js version from NodeSource repository"
 
   major_vers=10
-  version=$(apt-cache madison nodejs | grep 'unstable' | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
-  sudo apt-get install -y -q npm nodejs=$version
+  nodesrc_url="https://deb.nodesource.com/setup_$major_vers.x"
+  curl -sL "$nodesrc_url" -o repo-install.sh
+  sudo bash repo-install.sh
+
+  version=$(apt-cache madison nodejs | grep 'nodesource' | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
+  sudo apt-get install -y -q nodejs=$version
 fi
 cleantmp
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -142,7 +142,7 @@ elif [[ ${menu_choice} == "LTS" ]] ; then
   echo "Installing LTS node.js version from standard Debian repository"
 
   major_vers=10
-  version=$(apt-cache madison nodejs | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
+  version=$(apt-cache madison nodejs | grep 'unstable' | grep -E "^\snodejs\s|\s$major_vers" | cut -d'|' -f2 | sed 's|\s||g')
   sudo apt-get install -y -q npm nodejs=$version
 fi
 cleantmp

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -2,6 +2,7 @@
 
 source $(dirname "$0")/uninstall-common.sh
 
+nodesource_key='9FD3 B784 BC1C 6FC3 1A8A  0A1C 1655 A0AB 6857 6280'
 yarn_key='72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310'
 n_line_rgx='^[^#]*\bN_PREFIX='
 
@@ -38,13 +39,15 @@ echo "Removing bash completion..."
 sudo_rem_file "/etc/bash_completion.d/npm"
 sudo_rem_file "/etc/bash_completion.d/nvm"
 
-remove_package "yarn"
+remove_package "yarn" "nodejs" "npm"
 
-echo "Removing APT source"
+echo "Removing APT source(s)"
 sudo_rem_file "/etc/apt/sources.list.d/yarn.list"
+sudo_rem_file "/etc/apt/sources.list.d/nodesource.list"
 
-echo "Removing APT key"
+echo "Removing APT key(s)"
 sudo apt-key del "$yarn_key"
+sudo apt-key del "$nodesource_key"
 
 }
 

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -39,7 +39,7 @@ echo "Removing bash completion..."
 sudo_rem_file "/etc/bash_completion.d/npm"
 sudo_rem_file "/etc/bash_completion.d/nvm"
 
-remove_package "yarn" "nodejs" "npm"
+remove_package "yarn" "nodejs"
 
 echo "Removing APT source(s)"
 sudo_rem_file "/etc/apt/sources.list.d/yarn.list"


### PR DESCRIPTION
Adds options to install either latest or LTS versions of node.js (+ npm) via the APT package manager using NodeSource repositories (distribution repositories for node.js, e.g. latest Debian LTS version, are strongly discouraged apparently).

Also adds wording to install menu letting users know that 'n' and 'nvm' are not compatible with the fish shell.