### PR TITLE
node.js n + nvm fish shell workarounds

### DIFF
--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -95,6 +95,19 @@ if [[ ${menu_choice} == "N" ]] ; then
   curl -0 -L https://npmjs.com/install.sh -o install.sh
   sh install.sh
 
+  # Add n to fish shell
+  FISH_DIR='/etc/fish/conf.d'
+  FISH_CONF="$FISH_DIR/n-prefix.fish"
+  cat << EOF >> $FISH_CONF
+#!/bin/fish
+
+set -x N_PREFIX $HOME/n
+
+if not contains -- $N_PREFIX/bin $PATH
+  set PATH $N_PREFIX/bin $PATH
+end
+EOF
+
   # Add npm to bash completion
   sudo mkdir -p /etc/bash_completion.d
   npm completion | sudo tee /etc/bash_completion.d/npm
@@ -118,6 +131,19 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   echo "$NVM_SH" | sudo tee -a /etc/profile.d/nvm-prefix.sh
   sudo mkdir -p /etc/bash_completion.d
   echo "$NVM_COMP" | sudo tee /etc/bash_completion.d/nvm
+
+  # Add nvm to fish shell
+  FISH_DIR='/etc/fish/conf.d'
+  FISH_CONF="$FISH_DIR/nvm-prefix.fish"
+  cat << EOF >> $FISH_CONF
+#!/bin/fish
+
+set -x NVM_DIR $HOME/.nvm
+
+function nvm
+  bass . "$NVM_DIR/nvm.sh" ';' nvm $argv
+end
+EOF
 
   # Add the path for sudo
   #SUDO_PATH="$(sudo cat /etc/sudoers | grep "secure_path" | sed "s/\(^.*secure_path=\"\)\(.*\)\(\"\)/\2/")"

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -98,7 +98,9 @@ if [[ ${menu_choice} == "N" ]] ; then
   # Add n to fish shell
   FISH_DIR='/etc/fish/conf.d'
   FISH_CONF="$FISH_DIR/n-prefix.fish"
-  cat << EOF >> $FISH_CONF
+
+  sudo mkdir -p "$FISH_DIR"
+  sudo sh -c "cat > $FISH_CONF" << EOF
 #!/bin/fish
 
 set -x N_PREFIX $HOME/n
@@ -135,13 +137,23 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   # Add nvm to fish shell
   FISH_DIR='/etc/fish/conf.d'
   FISH_CONF="$FISH_DIR/nvm-prefix.fish"
-  cat << EOF >> $FISH_CONF
+
+  sudo mkdir -p "$FISH_DIR"
+  sudo sh -c "cat > $FISH_CONF" << EOF
 #!/bin/fish
 
 set -x NVM_DIR $HOME/.nvm
 
 function nvm
   bass . "$NVM_DIR/nvm.sh" ';' nvm $argv
+end
+
+function npm
+  bass . "$NVM_DIR/nvm.sh" ';' npm $argv
+end
+
+function node
+  bass . "$NVM_DIR/nvm.sh" ';' node $argv
 end
 EOF
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -15,9 +15,9 @@ fi
 echo "Offering user n / nvm version manager choice"
 menu_choice=$(
 
-  menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 85 4 \
-    "N" "Install with n version manager (NOT fish shell compatible)" off \
-    "NVM" "Install with nvm version manager (NOT fish shell compatible)" off \
+  menu --title "nodejs" --radiolist "Choose Node.js install method\n[SPACE to select, ENTER to confirm]:" 12 90 4 \
+    "N" "Install with n version manager (fish shell compat. EXPERIMENTAL)" off \
+    "NVM" "Install with nvm version manager (fish shell compat. EXPERIMENTAL)" off \
     "LATEST" "Install latest version via APT package manager" off \
     "LTS" "Install LTS version via APT package manager" off \
 

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -96,7 +96,7 @@ if [[ ${menu_choice} == "N" ]] ; then
   sh install.sh
 
   # Add n to fish shell
-  FISH_DIR='/etc/fish/conf.d'
+  FISH_DIR="$HOME/.config/fish/conf.d"
   FISH_CONF="$FISH_DIR/n-prefix.fish"
 
   sudo mkdir -p "$FISH_DIR"
@@ -135,7 +135,7 @@ elif [[ ${menu_choice} == "NVM" ]] ; then
   echo "$NVM_COMP" | sudo tee /etc/bash_completion.d/nvm
 
   # Add nvm to fish shell
-  FISH_DIR='/etc/fish/conf.d'
+  FISH_DIR="$HOME/.config/fish/conf.d"
   FISH_CONF="$FISH_DIR/nvm-prefix.fish"
 
   sudo mkdir -p "$FISH_DIR"

--- a/pengwin-setup.d/shells.sh
+++ b/pengwin-setup.d/shells.sh
@@ -80,8 +80,11 @@ function fish_install() {
     curl -L https://get.oh-my.fish | fish
     cd ..
 
-    #Change the default theme for one more friendly with Windows console default font
+    # Change the default theme for one more friendly with Windows console default font
     fish -c "omf install bira"
+
+    # Install bash compatibility plugin
+    fish -c "omf install bass"
 
     cleantmp
   else

--- a/pengwin-setup.d/shells.sh
+++ b/pengwin-setup.d/shells.sh
@@ -31,7 +31,7 @@ if [ -f "/etc/zsh/zshrc" ] ; then
         # Reset after to prevent any unforeseen consequences.
         # ALTERNATIVE: "shopt -s failglob" in /etc/profile fixes bash to act more like zsh (we're currently doing reverse)
         # This would prevent issues in other shell alternatives if they appear.
-        
+
         echo "Creating fresh zshrc, modifying to add pengwin template commands and source /etc/profile"
         if [[ ! -d "/etc/zsh" ]] ; then
             echo "/etc/zsh not found, creating..."
@@ -53,8 +53,8 @@ fi
 if (whiptail --title "zsh" --yesno "Would you like to download and install oh-my-zsh? This is a framework for managing your zsh installation" 8 95) then
     createtmp
     whiptail --title "zsh" --msgbox "After oh-my-zsh is installed and launched, type 'exit' and ENTER to return to pengwin-setup" 8 95
-    mkdir "Type exit to return to pengwin-setup" 
-    cd "Type exit to return to pengwin-setup" 
+    mkdir "Type exit to return to pengwin-setup"
+    cd "Type exit to return to pengwin-setup"
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
     cd ..
 
@@ -72,24 +72,24 @@ fi
 }
 
 function fish_install() {
-  if (whiptail --title "fish" --yesno "Would you like to download and install oh-my-fish?" 8 55); then
-    createtmp
-    whiptail --title "fish" --msgbox "After oh my fish is installed and launched, type 'exit' and ENTER to return to pengwin-setup" 8 95
-    mkdir "Type exit to return to pengwin-setup"
-    cd "Type exit to return to pengwin-setup"
-    curl -L https://get.oh-my.fish | fish
-    cd ..
+  createtmp
+  sudo apt install fish python -y # /usr/bin/python required for omf
 
-    # Change the default theme for one more friendly with Windows console default font
-    fish -c "omf install bira"
+  whiptail --title "fish" --msgbox "After oh my fish is installed and launched, type 'exit' and ENTER to return to pengwin-setup" 8 95
 
-    # Install bash compatibility plugin
-    fish -c "omf install bass"
+  mkdir "Type exit to return to pengwin-setup"
+  cd "Type exit to return to pengwin-setup"
 
-    cleantmp
-  else
-    echo "Skipping Oh My Fish"
-  fi
+  curl -L https://get.oh-my.fish | fish
+  cd ..
+
+  # Change the default theme for one more friendly with Windows console default font
+  fish -c "omf install bira"
+
+  # Install bash compatibility plugin
+  fish -c "omf install bass"
+
+  cleantmp
 
   if (confirm --title "fish" --yesno "Would you like to set fish as the default shell?" 8 55); then
     chsh -s "$(which fish)"
@@ -107,7 +107,7 @@ function installandsetshell {
 
     menu --title "Shell Menu" --checklist --separate-output "Custom shells and improvements (bash included)\n[SPACE to select, ENTER to confirm]:" 12 80 4 \
         "ZSH" "zsh" off \
-        "FISH" "fish" off \
+        "FISH" "fish with oh-my-fish plugin manager" off \
         "CSH" "csh" off \
         "BASH-RL" "Recommended readline settings for productivity " off
 
@@ -123,7 +123,6 @@ function installandsetshell {
 
   if [[ $menu_choice == *"FISH"* ]] ; then
     echo "Installing fish..."
-    sudo apt install fish -y
     fish_install
   fi
 

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -29,6 +29,8 @@ echo "Removing PATH modifier(s)..."
 sudo_rem_file "/etc/profile.d/n-prefix.sh"
 sudo_rem_file "/etc/profile.d/nvm-prefix.sh"
 sudo_rem_file "/etc/profile.d/rm-win-npm-path.sh"
+sudo_rem_file "/etc/fish/conf.d/n-prefix.sh"
+sudo_rem_file "/etc/fish/conf.d/nvm-prefix.sh"
 # The .bashrc path clean shouldn't be needed on newer installs, but takes into account legacy pengwin-setup nodejs installs
 if [[ -f "$HOME/.bashrc" ]] ; then
 	echo "$HOME/.bashrc found, cleaning"

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -26,11 +26,17 @@ rem_dir "$HOME/.npm"
 rem_dir "$HOME/.nvm"
 
 echo "Removing PATH modifier(s)..."
+sudo_rem_file "/etc/profile.d/rm-win-npm-path.sh"
+
+# Bash + other shell config removal
 sudo_rem_file "/etc/profile.d/n-prefix.sh"
 sudo_rem_file "/etc/profile.d/nvm-prefix.sh"
-sudo_rem_file "/etc/profile.d/rm-win-npm-path.sh"
-sudo_rem_file "/etc/fish/conf.d/n-prefix.fish"
-sudo_rem_file "/etc/fish/conf.d/nvm-prefix.fish"
+
+# Fish config reomval
+fish_conf_dir="$HOME/.config/fish/conf.d"
+rem_file "$fish_conf_dir/n-prefix.fish"
+rem_file "$fish_conf_dir/nvm-prefix.fish"
+
 # The .bashrc path clean shouldn't be needed on newer installs, but takes into account legacy pengwin-setup nodejs installs
 if [[ -f "$HOME/.bashrc" ]] ; then
 	echo "$HOME/.bashrc found, cleaning"

--- a/pengwin-setup.d/uninstall/nodejs.sh
+++ b/pengwin-setup.d/uninstall/nodejs.sh
@@ -29,8 +29,8 @@ echo "Removing PATH modifier(s)..."
 sudo_rem_file "/etc/profile.d/n-prefix.sh"
 sudo_rem_file "/etc/profile.d/nvm-prefix.sh"
 sudo_rem_file "/etc/profile.d/rm-win-npm-path.sh"
-sudo_rem_file "/etc/fish/conf.d/n-prefix.sh"
-sudo_rem_file "/etc/fish/conf.d/nvm-prefix.sh"
+sudo_rem_file "/etc/fish/conf.d/n-prefix.fish"
+sudo_rem_file "/etc/fish/conf.d/nvm-prefix.fish"
 # The .bashrc path clean shouldn't be needed on newer installs, but takes into account legacy pengwin-setup nodejs installs
 if [[ -f "$HOME/.bashrc" ]] ; then
 	echo "$HOME/.bashrc found, cleaning"


### PR DESCRIPTION
the workaround for n is very simple just adding `$HOME/n/bin` to user path and ensuring the `N_PREFIX` variable is set, but nvm requires use of an omf plugin `bass` and setting nvm within a function