### PR TITLE
Fixed a problem in generating shortcut in Start menu in WSL 2

### DIFF
--- a/pengwin-setup.d/shortcut.sh
+++ b/pengwin-setup.d/shortcut.sh
@@ -175,7 +175,15 @@ function main() {
 
     rm "${DEST_PATH}"/*
 
-    find /usr/share/applications -name '*.desktop' | while read desktopFile; do
+    filelistarray=()
+
+    while IFS=  read -r -d $'\0'; do
+
+        filelistarray+=("$REPLY")
+
+    done < <(find /usr/share/applications -name '*.desktop' -print0)
+
+    for desktopFile in "${filelistarray[@]}"; do
 
       create_shortcut_from_desktop "${desktopFile}"
 


### PR DESCRIPTION
currently using Start Menu shortcut generation on WSL 2 will only generate only one shortcut. This pr is trying to fix this problem.