### PR TITLE
node is an alias for the latest version

### DIFF
--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -166,7 +166,7 @@ EOF
   #echo "Defaults secure_path=\"${SUDO_PATH}:${NVM_DIR}/bin\"" | sudo EDITOR='tee ' visudo --quiet --file=/etc/sudoers.d/npm-path
 
   echo "Installing latest Node.js release"
-  nvm install "$(nvm ls-remote | tail -1 | sed -e 's|^\s||g')" --latest-npm
+  nvm install node --latest-npm
 
   # Add npm to bash completion
   npm completion | sudo tee /etc/bash_completion.d/npm


### PR DESCRIPTION
Changes the nvm install step from `nvm ls-remote` to `node` as an alias for the latest version.

Fixes WhitewaterFoundry/Pengwin#584