### PR TITLE
Add option to have a ignore file to backup

### DIFF
--- a/pengwin-setup.d/home-backup.sh
+++ b/pengwin-setup.d/home-backup.sh
@@ -9,6 +9,7 @@ declare SetupDir
 BACKUPS_DIR="${wHome}/Pengwin/backups"
 BACKUP_PATH="${BACKUPS_DIR}/pengwin_home.tgz"
 BACKUP_PATH_WIN="$(wslpath -w "${BACKUP_PATH}")"
+BACKUP_IGNORE_FILE="${HOME}/.pengwinbackupignore"
 
 function backup() {
 
@@ -27,7 +28,13 @@ function backup() {
       mkdir -p "${BACKUPS_DIR}"
     fi
 
-    tar -czvf "${BACKUP_PATH}" ${HOME}
+    #To runs backup with a list of files to be ignored
+    if [[ -f "${BACKUP_PATH}" ]]; then
+      tar -czvf "${BACKUP_PATH}" -X ${BACKUP_IGNORE_FILE} ${HOME}
+    else
+      tar -czvf "${BACKUP_PATH}" ${HOME}
+    fi
+
   else
     echo "Skipping BACKUP"
   fi

--- a/pengwin-setup.d/home-backup.sh
+++ b/pengwin-setup.d/home-backup.sh
@@ -29,10 +29,10 @@ function backup() {
     fi
 
     #To runs backup with a list of files to be ignored
-    if [[ -f "${BACKUP_PATH}" ]]; then
-      tar -czvf "${BACKUP_PATH}" -X ${BACKUP_IGNORE_FILE} ${HOME}
+    if [[ -f "${BACKUP_IGNORE_FILE}" ]]; then
+      tar -czvf "${BACKUP_PATH}" -X "${BACKUP_IGNORE_FILE}" "${HOME}"
     else
-      tar -czvf "${BACKUP_PATH}" ${HOME}
+      tar -czvf "${BACKUP_PATH}" "${HOME}"
     fi
 
   else


### PR DESCRIPTION
Add a feature to allow user to create a file named .pengwinbackupignore in home folder. to set a list of folder and files to be ignored for backup script

Implement: PEN-570