### PR TITLE
Make Poetry available in current shell after installation

### DIFF
--- a/pengwin-setup.d/pythonpi.sh
+++ b/pengwin-setup.d/pythonpi.sh
@@ -74,6 +74,7 @@ function install_poetry() {
     createtmp
     install_packages build-essential python3.9 python3.9-distutils idle-python3.9 python3-venv
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+    source $HOME/.poetry/env
     poetry self update
     poetry completions bash | sudo tee /usr/share/bash-completion/completions/poetry.bash-completion
 


### PR DESCRIPTION
Ran into this when starting a fresh new Pengwin install. Found this issue and comment from Poetry: https://github.com/python-poetry/poetry/issues/532#issuecomment-431417497 which suggests sourcing it. Also without sourcing, restarting WSL doesn't cause the shell to update, which is odd. This change fixes the issue presuming it's the normal user shell  that's sourced and not root. It will fail in the case of root unless pengwin setup is run directly by root (which is not supported by Pengwin).