### PR TITLE
Make Poetry available to user shell after installation

### DIFF
--- a/pengwin-setup.d/pythonpi.sh
+++ b/pengwin-setup.d/pythonpi.sh
@@ -74,6 +74,7 @@ function install_poetry() {
     createtmp
     install_packages build-essential python3.9 python3.9-distutils idle-python3.9 python3-venv
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+    source $HOME/.poetry/env
     poetry self update
     poetry completions bash | sudo tee /usr/share/bash-completion/completions/poetry.bash-completion
 

--- a/rpm/pengwin-setup.d/pythonpi.sh
+++ b/rpm/pengwin-setup.d/pythonpi.sh
@@ -74,6 +74,7 @@ function install_poetry() {
     createtmp
     install_packages build-essential python3.9 python3.9-distutils idle-python3.9 python3-venv
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+    source $HOME/.poetry/env
     poetry self update
     poetry completions bash | sudo tee /usr/share/bash-completion/completions/poetry.bash-completion
 


### PR DESCRIPTION
Ran into this issue on a fresh Pengwin install. Restarting WSL didn't help with sourcing Poetry so I've explicitly sourced it. Got the idea to do this from https://github.com/python-poetry/poetry/issues/532#issuecomment-431417497. Only caveat is this will only work for the current user running pengwin setup. So this won't work on root (as running pengwin-setup as root isn't supported).

Also noticed you added rpm support so I added the fix there too to keep it consistent. Looking forward to trying the rpm setup using FedoraRemix once it's ready.