### PR TITLE
fix gopath

### DIFF
--- a/pengwin-setup.d/go.sh
+++ b/pengwin-setup.d/go.sh
@@ -24,7 +24,7 @@ if (confirm --title "GO" --yesno "Would you like to download and install the lat
 #!/bin/sh
 
 export GOROOT="/usr/local/go"
-export GOPATH="\${HOME}/go/"
+export GOPATH="\${HOME}/go"
 export PATH="\${GOPATH}/bin:\${GOROOT}/bin:/usr/local/go/bin:\${PATH}"
 
 EOF
@@ -36,7 +36,7 @@ EOF
 #!/bin/fish
 
 set --export GOROOT "/usr/local/go"
-set --export GOPATH "\$HOME/go/"
+set --export GOPATH "\$HOME/go"
 set --export PATH "\$GOPATH/bin:\$GOROOT/bin:/usr/local/go/bin:\$PATH"
 
 EOF


### PR DESCRIPTION
fixed gopath.

Since the last slash in GOPATH is unnecessary, the slash in PATH was doubled as in the example below.
```
$ echo $GOPATH
/home/commojun/go/
$ echo $PATH
... :/home/commojun/go//bin:/usr/local/go/bin: ...
```
This isn't a fatal problem in a normal shell, but Emacs wasn't able to correctly recognize duplicate slashes when using this PATH.