### PR TITLE
[Fixed], now if you press ESC it won't tell you that no item was selected

### DIFF
--- a/pengwin-setup.d/common.sh
+++ b/pengwin-setup.d/common.sh
@@ -289,7 +289,7 @@ function menu() {
 
   local exit_status=$?
 
-  if [[ ${exit_status} == 1 ]]; then
+  if [[ ${exit_status} == 1 || ${exit_status} == 255 ]]; then
     echo "${CANCELLED}"
     return
   fi


### PR DESCRIPTION
This pull request includes a small change to the `pengwin-setup.d/common.sh` file. The change modifies the `menu` function to handle an additional exit status code.

* [`pengwin-setup.d/common.sh`](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L292-R292): Updated the `if` condition in the `menu` function to check for an exit status of `255` in addition to `1`.