### PR TITLE
Add MSEDIT to pengwin-setup

### DIFF
--- a/completions/pengwin-setup
+++ b/completions/pengwin-setup
@@ -6,7 +6,7 @@ function _pengwin_setup() { #  By convention, the function name
 
   case "$prev" in
   EDITORS)
-    mapfile -t COMPREPLY < <(compgen -W 'CODE EMACS NEOVIM' -- "${cur}")
+    mapfile -t COMPREPLY < <(compgen -W 'CODE EMACS NEOVIM MSEDIT' -- "${cur}")
     ;;
   GUI)
     mapfile -t COMPREPLY < <(compgen -W 'CONFIGURE DESKTOP NLI GUILIB HIDPI TERMINAL SYNAPTIC WINTHEME WSLG' -- "${cur}")

--- a/pengwin-setup.d/editors.sh
+++ b/pengwin-setup.d/editors.sh
@@ -69,9 +69,9 @@ function editor_menu() {
   # shellcheck disable=SC2155
   local editor_choice=$(
 
-    menu --title "Editor Menu" --menu "Custom editors (nano and vi included)\n[ENTER to confirm]:" 14 70 3 \
+    menu --title "Editor Menu" --menu "Custom editors (nano and vi included)\n[ENTER to confirm]:" 14 70 4 \
       "CODE" "Visual Studio Code Linux version${REQUIRES_X}   " \
-      "MSEDIT" "Microsoft Edit CLI" \
+      "MSEDIT" "Microsoft Edit Linux version" \
       "EMACS" "Emacs" \
       "NEOVIM" "Neovim"
 
@@ -97,9 +97,6 @@ function editor_menu() {
 
   if [[ ${editor_choice} == *"MSEDIT"* ]]; then
     bash "${SetupDir}"/microsoft-edit.sh "$@"
-    if [[ -f /usr/local/bin/edit ]]; then
-      INSTALLED=true
-    fi
   fi
 
   if [[ "${INSTALLED}" == true ]]; then

--- a/pengwin-setup.d/microsoft-edit.sh
+++ b/pengwin-setup.d/microsoft-edit.sh
@@ -7,9 +7,9 @@ readonly EDIT_GITHUB_API_URL="https://api.github.com/repos/microsoft/edit/releas
 readonly EDIT_INSTALL_DEST="/usr/local/bin/edit"
 
 function msedit_install() {
-  if (confirm --title "MICROSOFT EDIT" --yesno "Would you like to download and install Microsoft Edit CLI?" 8 70); then
+  if (confirm --title "Microsoft Edit" --yesno "Would you like to download and install Microsoft Edit?" 8 70); then
     echo "Installing Microsoft Edit"
-    install_packages curl jq tar zstd
+    install_packages jq zstd
 
     createtmp
 
@@ -52,7 +52,6 @@ function msedit_install() {
     sudo update-alternatives --install /usr/bin/editor editor "${EDIT_INSTALL_DEST}" 30
 
     cleantmp
-    INSTALLED=true
   else
     echo "Skipping Microsoft Edit"
   fi

--- a/pengwin-setup.d/terminal.sh
+++ b/pengwin-setup.d/terminal.sh
@@ -135,6 +135,7 @@ function main() {
 #!/bin/bash
 
 export QT_STYLE_OVERRIDE=Breeze
+export QT_QPA_PLATFORM="wayland;xcb"
 
 EOF
 

--- a/pengwin-setup.d/uninstall.sh
+++ b/pengwin-setup.d/uninstall.sh
@@ -35,6 +35,7 @@ function main() {
       "KEYCHAIN" "Remove Keychain OpenSSH key manager" \
       "KUBERNETES" "Remove Kubernetes tooling" \
       "LAMP" "Remove LAMP stack" \
+      "MSEDIT" "Remove Microsoft Edit TUI editor" \
       "NIM" "Remove choosenim and any installed Nim components" \
       "NODEJS" "Remove Node.js, npm and Yarn (if installed)" \
       "OPENSTACK" "Remove OpenStack CLI tools" \
@@ -181,6 +182,11 @@ function main() {
   if [[ ${menu_choice} == *"NIM"* ]]; then
     echo "NIM"
     bash "${UninstallDir}"/nim.sh "$@"
+  fi
+
+  if [[ ${menu_choice} == *"MSEDIT"* ]]; then
+    echo "MSEDIT"
+    bash "${UninstallDir}"/microsoft-edit.sh "$@"
   fi
 
   if [[ ${menu_choice} == *"NODEJS"* ]]; then

--- a/tests/microsoft_edit.sh
+++ b/tests/microsoft_edit.sh
@@ -3,7 +3,7 @@
 source commons.sh
 
 function test_main() {
-  run_pengwinsetup autoinstall EDITORS MSEDIT
+  run_pengwinsetup install EDITORS MSEDIT
 
   assertTrue "Microsoft Edit binary missing" "[ -f /usr/local/bin/edit ]"
   command -v /usr/local/bin/edit
@@ -12,7 +12,7 @@ function test_main() {
 }
 
 function test_uninstall() {
-  run_pengwinsetup autoinstall UNINSTALL MSEDIT
+  run_pengwinsetup install UNINSTALL MSEDIT
 
   assertFalse "Microsoft Edit binary still present" "[ -f /usr/local/bin/edit ]"
   assertEquals "update-alternatives entry still present" "0" "$(run update-alternatives --list editor | grep -c '/usr/local/bin/edit')"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -55,12 +55,12 @@ elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #5
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #6
   #run_test ./lamp.sh "10.9"
   run_test ./brew.sh
-  run_test ./microsoft_edit.sh
   run_test ./nodejs_latest.sh
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #7
   run_test ./pythonpi.sh
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #8
   run_test ./java.sh
+  run_test ./microsoft_edit.sh
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #9
   run_test ./kubernetes.sh
   run_test ./go.sh


### PR DESCRIPTION
This pull request introduces support for Microsoft Edit (MSEDIT), a new text editor option in the `pengwin-setup` tool. It includes changes to add installation, uninstallation, and testing functionality for MSEDIT, along with updates to menus and scripts to integrate this feature seamlessly.

### Integration of Microsoft Edit (MSEDIT):

#### Installation Support:
* Added `microsoft-edit.sh` script to handle the installation of Microsoft Edit, including downloading the latest release, extracting the binary, and configuring `update-alternatives`. (`pengwin-setup.d/microsoft-edit.sh`, [pengwin-setup.d/microsoft-edit.shR1-R60](diffhunk://#diff-691f2c0dbfe94c7c81856dc4e9d0de94ebb9fec6dfc297a73a140d8b8717ae99R1-R60))

#### Uninstallation Support:
* Added `microsoft-edit.sh` script to remove Microsoft Edit and its `update-alternatives` configuration. (`pengwin-setup.d/uninstall/microsoft-edit.sh`, [pengwin-setup.d/uninstall/microsoft-edit.shR1-R14](diffhunk://#diff-d74c93cbc31eacab89ce7fb5f1bd27c9cec75382f33551b629f11b9d5deef577R1-R14))

#### Menu Updates:
* Updated the `EDITORS` menu to include MSEDIT as an option. (`pengwin-setup.d/editors.sh`, [pengwin-setup.d/editors.shL72-R74](diffhunk://#diff-86570b3813aab4b383f5f6a97c4724de8062591877c051d6702aa9a0dad70bf2L72-R74))
* Integrated MSEDIT into the uninstall menu for removal options. (`pengwin-setup.d/uninstall.sh`, [[1]](diffhunk://#diff-ad71f34e3da4f7e1fd3c1ec0e5d052b929f0df44d53b5946af0b5ad9be30c892R38) [[2]](diffhunk://#diff-ad71f34e3da4f7e1fd3c1ec0e5d052b929f0df44d53b5946af0b5ad9be30c892R187-R191)

#### Testing:
* Added a new test script, `microsoft_edit.sh`, to verify the installation and uninstallation of Microsoft Edit. (`tests/microsoft_edit.sh`, [tests/microsoft_edit.shR1-R22](diffhunk://#diff-3072ad0e7994761d0f9c71d025d325188a0ca6ad2574b3fd81ef32b237b0a8faR1-R22))
* Integrated the new test into the `run_tests.sh` script for automated testing. (`tests/run_tests.sh`, [[1]](diffhunk://#diff-bfa67bbd428f0fd40485bf6e666132a2adb30f6524631aff49d2bcd30f71c5ebR25) [[2]](diffhunk://#diff-bfa67bbd428f0fd40485bf6e666132a2adb30f6524631aff49d2bcd30f71c5ebR58)