### PR TITLE
Add VSOCK option for X410 setup

### DIFF
--- a/pengwin-setup.d/x410.sh
+++ b/pengwin-setup.d/x410.sh
@@ -7,14 +7,55 @@ source "$(dirname "$0")/common.sh" "$@"
 if [ -x "$(command -v x410.exe)" ]; then
   if (confirm --title "X410" --yesno "It seems that X410 is already installed on your machine. Would you like to start it every time that Pengwin launches?" 10 80) then
     echo "Configuring X410 to start on Pengwin launch"
-    sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOF
+
+    connection=
+
+    for arg in "$@"; do
+      case "$arg" in
+        VSOCK)
+          connection=VSOCK
+          ;;
+        TCP)
+          connection=TCP
+          ;;
+      esac
+    done
+
+    if [[ -z ${connection} ]]; then
+      connection=$(menu --title "X410" --radiolist "Select how Pengwin connects to X410" 10 60 2 \
+        "TCP" "Use a TCP/IP connection" \
+        "VSOCK" "Use a VSOCK connection" 3>&1 1>&2 2>&3)
+
+      if [[ ${connection} == "${CANCELLED}" ]]; then
+        echo "Skipping X410"
+        exit 0
+      fi
+    fi
+
+    if [[ ${connection} == VSOCK ]]; then
+      sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOP
 #!/bin/sh
 
-(cmd-exe /c x410.exe /wm &> /dev/null &)
+(cmd-exe /c x410.exe /wm /vsock &> /dev/null &)
 
 export X410=yes
 
-EOF
+EOP
+    else
+      sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOP
+#!/bin/sh
+
+if [ -n "\${WSL2}" ]; then
+  (cmd-exe /c x410.exe /wm /public &> /dev/null &)
+else
+  (cmd-exe /c x410.exe /wm &> /dev/null &)
+fi
+
+export X410=yes
+
+EOP
+    fi
+
     #add_fish_support '02-x410'
 
     #Make sure that DISPLAY points to the internal IP address

--- a/rpm/pengwin-setup.d/x410.sh
+++ b/rpm/pengwin-setup.d/x410.sh
@@ -7,7 +7,42 @@ source "$(dirname "$0")/common.sh" "$@"
 if [ -x "$(command -v x410.exe)" ]; then
   if (confirm --title "X410" --yesno "It seems that X410 is already installed on your machine. Would you like to start it every time that Pengwin launches?" 10 80) then
     echo "Configuring X410 to start on Pengwin launch"
-    sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOF
+
+    connection=
+
+    for arg in "$@"; do
+      case "$arg" in
+        VSOCK)
+          connection=VSOCK
+          ;;
+        TCP)
+          connection=TCP
+          ;;
+      esac
+    done
+
+    if [[ -z ${connection} ]]; then
+      connection=$(menu --title "X410" --radiolist "Select how Pengwin connects to X410" 10 60 2 \
+        "TCP" "Use a TCP/IP connection" \
+        "VSOCK" "Use a VSOCK connection" 3>&1 1>&2 2>&3)
+
+      if [[ ${connection} == "${CANCELLED}" ]]; then
+        echo "Skipping X410"
+        exit 0
+      fi
+    fi
+
+    if [[ ${connection} == VSOCK ]]; then
+      sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOP
+#!/bin/bash
+
+(cmd-exe /c x410.exe /wm /vsock &> /dev/null &)
+
+export X410=yes
+
+EOP
+    else
+      sudo bash -c 'cat > /etc/profile.d/02-x410.sh' << EOP
 #!/bin/bash
 
 if [ -n "\${WSL2}" ]; then
@@ -16,7 +51,11 @@ else
   (cmd-exe /c x410.exe /wm &> /dev/null &)
 fi
 
-EOF
+export X410=yes
+
+EOP
+    fi
+
     # Avoid collision with the other XServer
     sudo rm -f /etc/profile.d/01-vcxsrv.sh
     touch "${HOME}"/.should-restart

--- a/tests/x410.sh
+++ b/tests/x410.sh
@@ -4,18 +4,18 @@
 source commons.sh
 source mocks.sh
 
-function testX410() {
-  run_pengwinsetup install GUI CONFIGURE X410
+function testX410Tcp() {
+  run_pengwinsetup install GUI CONFIGURE X410 TCP
 
   assertTrue "FILE PROFILE-X410" "[ -f /etc/profile.d/02-x410.sh ]"
+  assertFalse "VSOCK NOT PRESENT" "grep -q '/vsock' /etc/profile.d/02-x410.sh"
+}
 
-  #WSL2= bash /etc/profile.d/02-x410.sh
-  #verify_call "cmd.exe /c x410.exe /wm"
-  #assertTrue "X410 WSL1" "$?"
+function testX410Vsock() {
+  run_pengwinsetup install GUI CONFIGURE X410 VSOCK
 
-  #WSL2=1 bash /etc/profile.d/02-x410.sh
-  #verify_call "cmd.exe /c x410.exe /wm /public"
-  #assertTrue "X410 WSL2" "$?"
+  assertTrue "FILE PROFILE-X410" "[ -f /etc/profile.d/02-x410.sh ]"
+  assertTrue "VSOCK PRESENT" "grep -q '/vsock' /etc/profile.d/02-x410.sh"
 }
 
 function testUninstall() {


### PR DESCRIPTION
## Summary
- allow selecting TCP or VSOCK connection when configuring X410
- cover both connection types with unit tests

## Testing
- `./tests/x410.sh`
- `shellcheck pengwin-setup.d/x410.sh rpm/pengwin-setup.d/x410.sh tests/x410.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b849b703188327985009959acde288