### PR TITLE
Fix/enable multiple selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
             branches:
               only: master
           requires:
-            - test
+            #- test
             - build
             - shellcheck
   deploydevbranch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Check Scripts
           command: |
             find . -type f -name '*.sh' | wc -l
-            find . -type f -name '*.sh' | xargs shellcheck --external-sources --severity=error --source-path="${PWD}/pengwin-setup.d:${PWD}/pengwin-setup.d/uninstall:tests"
+            find . -type f -name '*.sh' | xargs shellcheck -e SC2218 --external-sources --severity=error --source-path="${PWD}/pengwin-setup.d:${PWD}/pengwin-setup.d/uninstall:tests"
             find . -type f -name '*.sh' | xargs shellcheck --external-sources --severity=style --source-path="${PWD}/pengwin-setup.d:${PWD}/pengwin-setup.d/uninstall:tests" || echo "Shellcheck has some warnings"
   build:
     docker:

--- a/completions/pengwin-setup
+++ b/completions/pengwin-setup
@@ -49,7 +49,7 @@ function _pengwin_setup() { #  By convention, the function name
     ;;
   *)
     mapfile -t COMPREPLY < <(compgen -W "--debug -d --verbose -v -y --yes --assume-yes --noupdate --norebuildicons -q \
-    --quiet --noninteractive -w --whiptail -n --ncurses --dialog --alt --help \
+    --quiet --noninteractive -w --whiptail -n --ncurses --dialog --alt --multiple --help \
     upgrade autoinstall install uninstall remove startmenu \
     EDITORS GUI MAINTENANCE PROGRAMMING SERVICES SETTINGS TOOLS UNINSTALL" -- "${cur}")
     ;;

--- a/pengwin-setup
+++ b/pengwin-setup
@@ -17,6 +17,9 @@ declare CANCELLED
 declare SKIP_UPDATES
 declare JUST_UPDATE
 declare REQUIRES_X
+declare DIALOG_TYPE
+declare OFF
+
 
 rm -f "${HOME}"/.should-restart
 
@@ -147,18 +150,18 @@ function bye_message() {
 
 # main menu
 function install_menu() {
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "pengwin-setup" --menu "\nHand-curated add-ons [ENTER to confirm]:" 0 0 0  \
-      "EDITORS" "Install text editors neovim, emacs, or Visual Studio Code${REQUIRES_X}"  \
-      "GUI" "Install an X server or various other GUI applications"  \
-      "MAINTENANCE" "Various maintenance tasks like home backup"  \
-      "PROGRAMMING" "Install various programming languages support"  \
-      "SERVICES" "Enable services support (SystemD, SSH, rc.local)"  \
-      "SETTINGS" "Change various settings in Pengwin"  \
-      "TOOLS" "Install applications or servers"  \
-      "UNINSTALL" "Uninstall applications and packages installed by pengwin-setup"
+    menu --title "pengwin-setup" "${DIALOG_TYPE}" "\nHand-curated add-ons [ENTER to confirm]:" 0 0 0  \
+      "EDITORS" "Install text editors neovim, emacs, or Visual Studio Code${REQUIRES_X}" ${OFF}  \
+      "GUI" "Install an X server or various other GUI applications" ${OFF}  \
+      "MAINTENANCE" "Various maintenance tasks like home backup" ${OFF}  \
+      "PROGRAMMING" "Install various programming languages support" ${OFF}  \
+      "SERVICES" "Enable services support (SystemD, SSH, rc.local)" ${OFF}  \
+      "SETTINGS" "Change various settings in Pengwin" ${OFF}  \
+      "TOOLS" "Install applications or servers" ${OFF}  \
+      "UNINSTALL" "Uninstall applications and packages installed by pengwin-setup" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3
@@ -238,6 +241,7 @@ Options:
   --noupdate                     Skip the update step before showing the setup.
   --norebuildicons               Skip rebuilding the start menu icons.
   -q, --quiet, --noninteractive  Run in non-interactive mode, skipping confirmations and prompts.
+  --multiple                     Allow to select multiple installers at once. (previous pengwin-setup behavior)
 
 Commands:
   update, upgrade                Just update packages without any other actions. Implies --yes and --noninteractive.

--- a/pengwin-setup.d/brew.sh
+++ b/pengwin-setup.d/brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 

--- a/pengwin-setup.d/cloudcli.sh
+++ b/pengwin-setup.d/cloudcli.sh
@@ -282,16 +282,16 @@ function install_openstack() {
 }
 
 function main() {
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
-    menu --title "Cloud Management Menu" --menu "CLI tools for cloud management\n[ENTER to confirm]:" 16 62 7 \
-      "AWS" "AWS CLI" \
-      "AZURE" "Azure CLI" \
-      "DO" "Digital Ocean CLI" \
-      "IBM" "IBM Cloud CLI" \
-      "KUBERNETES" "Kubernetes tooling (kubectl, helm)" \
-      "OPENSTACK" "OpenStack command-line clients      " \
-      "TERRAFORM" "Terraform                   "
+    menu --title "Cloud Management Menu" "${DIALOG_TYPE}" "CLI tools for cloud management\n[ENTER to confirm]:" 16 62 7 \
+      "AWS" "AWS CLI" ${OFF} \
+      "AZURE" "Azure CLI" ${OFF} \
+      "DO" "Digital Ocean CLI" ${OFF} \
+      "IBM" "IBM Cloud CLI" ${OFF} \
+      "KUBERNETES" "Kubernetes tooling (kubectl, helm)" ${OFF} \
+      "OPENSTACK" "OpenStack command-line clients      " ${OFF} \
+      "TERRAFORM" "Terraform                   " ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/colortool.sh
+++ b/pengwin-setup.d/colortool.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/dotnet.sh
+++ b/pengwin-setup.d/dotnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/editors.sh
+++ b/pengwin-setup.d/editors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare INSTALLED=false

--- a/pengwin-setup.d/editors.sh
+++ b/pengwin-setup.d/editors.sh
@@ -66,14 +66,14 @@ EOF
 }
 
 function editor_menu() {
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local editor_choice=$(
 
-    menu --title "Editor Menu" --menu "Custom editors (nano and vi included)\n[ENTER to confirm]:" 14 70 4 \
-      "CODE" "Visual Studio Code Linux version${REQUIRES_X}   " \
-      "MSEDIT" "Microsoft Edit Linux version" \
-      "EMACS" "Emacs" \
-      "NEOVIM" "Neovim"
+    menu --title "Editor Menu" "${DIALOG_TYPE}" "Custom editors (nano and vi included)\n[ENTER to confirm]:" 14 70 4 \
+      "CODE" "Visual Studio Code Linux version${REQUIRES_X}   " ${OFF} \
+      "MSEDIT" "Microsoft Edit Linux version" ${OFF} \
+      "EMACS" "Emacs" ${OFF} \
+      "NEOVIM" "Neovim" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/explorer.sh
+++ b/pengwin-setup.d/explorer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/fcitx.sh
+++ b/pengwin-setup.d/fcitx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/fzf.sh
+++ b/pengwin-setup.d/fzf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/go.sh
+++ b/pengwin-setup.d/go.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "GO" --yesno "Would you like to download and install the latest Go from Google?" 8 70); then

--- a/pengwin-setup.d/gui.sh
+++ b/pengwin-setup.d/gui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/gui.sh
+++ b/pengwin-setup.d/gui.sh
@@ -129,35 +129,38 @@ function main() {
 
   local -i more=0
   if [[ "${WSL2}" == "${WSLG}" ]]; then
-    local -a disable_wslg=("WSLG" "Force disable WSLg just for Pengwin")
+    # shellcheck disable=SC2206
+    local -a disable_wslg=("WSLG" "Force disable WSLg just for Pengwin" ${OFF})
     more=$((more + 1))
 
     local -a show_configure
   else
     if [[ "${wslg_disabled}" == true ]]; then
-      local -a disable_wslg=("WSLG" "Enable WSLg just for Pengwin")
+      # shellcheck disable=SC2206
+      local -a disable_wslg=("WSLG" "Enable WSLg just for Pengwin" ${OFF})
       more=$((more + 1))
     else
       local -a disable_wslg
     fi
 
-    local show_configure=("CONFIGURE" "Configure GUI (Check this first)")
+    # shellcheck disable=SC2206
+    local show_configure=("CONFIGURE" "Configure GUI (Check this first)" ${OFF})
     more=$((more + 1))
   fi
 
-  # shellcheck disable=SC2155,SC2188
+  # shellcheck disable=SC2155,SC2188,SC2086
   local menu_choice=$(
 
-    menu --title "GUI Menu" --menu "Install an X server or various other GUI applications\n[SPACE to select, ENTER to confirm]:" $((16 + more)) 99 $((7 + more)) \
+    menu --title "GUI Menu" "${DIALOG_TYPE}" "Install an X server or various other GUI applications\n[SPACE to select, ENTER to confirm]:" $((16 + more)) 99 $((7 + more)) \
       "${disable_wslg[@]}" \
       "${show_configure[@]}" \
-      "DESKTOP" "Install Desktop environments" \
-      "GUILIB" "Install a base set of libraries for GUI applications" \
-      "HIDPI" "Configure Qt and GTK for HiDPI displays" \
-      "NLI" "Install fcitx or iBus for improved non-Latin input support" \
-      "SYNAPTIC" "Install the Synaptic package manager" \
-      "TERMINAL" "Install Terminals on Windows or WSL for using WSL" \
-      "WINTHEME" "Install a Windows 10 theme along with the LXAppearance theme switcher   "
+      "DESKTOP" "Install Desktop environments" ${OFF} \
+      "GUILIB" "Install a base set of libraries for GUI applications" ${OFF} \
+      "HIDPI" "Configure Qt and GTK for HiDPI displays" ${OFF} \
+      "NLI" "Install fcitx or iBus for improved non-Latin input support" ${OFF} \
+      "SYNAPTIC" "Install the Synaptic package manager" ${OFF} \
+      "TERMINAL" "Install Terminals on Windows or WSL for using WSL" ${OFF} \
+      "WINTHEME" "Install a Windows 10 theme along with the LXAppearance theme switcher   " ${OFF}
 
     3>&1 1>&2 2>&3
   )

--- a/pengwin-setup.d/guilib.sh
+++ b/pengwin-setup.d/guilib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare WIN_CUR_VER

--- a/pengwin-setup.d/hidpi.sh
+++ b/pengwin-setup.d/hidpi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "HiDPI" --yesno "Would you like to configure Qt and GTK for HiDPI displays?" 8 85) then

--- a/pengwin-setup.d/home-backup.sh
+++ b/pengwin-setup.d/home-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/jetbrains-support.sh
+++ b/pengwin-setup.d/jetbrains-support.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SetupDir

--- a/pengwin-setup.d/keychain.sh
+++ b/pengwin-setup.d/keychain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/lamp.sh
+++ b/pengwin-setup.d/lamp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #######################################

--- a/pengwin-setup.d/language.sh
+++ b/pengwin-setup.d/language.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/latex.sh
+++ b/pengwin-setup.d/latex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/maintenance.sh
+++ b/pengwin-setup.d/maintenance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/maintenance.sh
+++ b/pengwin-setup.d/maintenance.sh
@@ -17,11 +17,11 @@ declare SetupDir
 #######################################
 function main() {
 
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Maintenance Menu" --menu "Various maintenance tasks like home backup\n[SPACE to select, ENTER to confirm]:" 12 70 1 \
-      "HOMEBACKUP" "Backups and restore the \${HOME} directory    "
+    menu --title "Maintenance Menu" "${DIALOG_TYPE}" "Various maintenance tasks like home backup\n[SPACE to select, ENTER to confirm]:" 12 70 1 \
+      "HOMEBACKUP" "Backups and restore the \${HOME} directory    " ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/microsoft-edit.sh
+++ b/pengwin-setup.d/microsoft-edit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 readonly EDIT_GITHUB_API_URL="https://api.github.com/repos/microsoft/edit/releases/latest"

--- a/pengwin-setup.d/motd.sh
+++ b/pengwin-setup.d/motd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #######################################

--- a/pengwin-setup.d/nim.sh
+++ b/pengwin-setup.d/nim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/nodejs.sh
+++ b/pengwin-setup.d/nodejs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SKIP_CONFIMATIONS

--- a/pengwin-setup.d/powershell.sh
+++ b/pengwin-setup.d/powershell.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "POWERSHELL" --yesno "Would you like to download and install Powershell?" 8 55); then

--- a/pengwin-setup.d/programming.sh
+++ b/pengwin-setup.d/programming.sh
@@ -7,22 +7,22 @@ declare SetupDir
 
 function main() {
 
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Programming Menu" --menu "Install various programming languages support\n[ENTER to confirm]:" 22 95 12 \
-      "C++" "Install support for Linux C/C++ programming in Visual Studio and CLion  " \
-      "DOTNET" "Install .NET Core SDK from Microsoft and optionally install NuGet  " \
-      "GO" "Install the latest Go from Google" \
-      "JAVA" "Install the SDKMan to manage Java SDKs" \
-      "JETBRAINS" "Install required support to jetbrains tools" \
-      "JOOMLA" "Install development support for Joomla" \
-      "LATEX" "Install TexLive for LaTeX Support" \
-      "NIM" "Install Nim from official sources using choosenim" \
-      "NODEJS" "Install Node.js and npm" \
-      "PYTHONPI" "Install Python 3.13, download and install latest PyPi" \
-      "RUBY" "Install Ruby using rbenv and optionally install Rails" \
-      "RUST" "Install latest version of Rust via rustup installer"
+    menu --title "Programming Menu" "${DIALOG_TYPE}" "Install various programming languages support\n[ENTER to confirm]:" 22 95 12 \
+      "C++" "Install support for Linux C/C++ programming in Visual Studio and CLion  " ${OFF} \
+      "DOTNET" "Install .NET Core SDK from Microsoft and optionally install NuGet  " ${OFF} \
+      "GO" "Install the latest Go from Google" ${OFF} \
+      "JAVA" "Install the SDKMan to manage Java SDKs" ${OFF} \
+      "JETBRAINS" "Install required support to jetbrains tools" ${OFF} \
+      "JOOMLA" "Install development support for Joomla" ${OFF} \
+      "LATEX" "Install TexLive for LaTeX Support" ${OFF} \
+      "NIM" "Install Nim from official sources using choosenim" ${OFF} \
+      "NODEJS" "Install Node.js and npm" ${OFF} \
+      "PYTHONPI" "Install Python 3.13, download and install latest PyPi" ${OFF} \
+      "RUBY" "Install Ruby using rbenv and optionally install Rails" ${OFF} \
+      "RUST" "Install latest version of Rust via rustup installer" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/pythonpi.sh
+++ b/pengwin-setup.d/pythonpi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #######################################

--- a/pengwin-setup.d/ruby.sh
+++ b/pengwin-setup.d/ruby.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/rust.sh
+++ b/pengwin-setup.d/rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/services.sh
+++ b/pengwin-setup.d/services.sh
@@ -211,16 +211,16 @@ function main() {
     return
   fi
 
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Services Menu" --menu "Enables various services\n[ENTER to confirm]:" 14 70 6 \
-      "CASSANDRA" "Install the NoSQL server Cassandra from Apache " \
-      "KEYCHAIN" "Install Keychain, the OpenSSH key manager" \
-      "LAMP" "Install LAMP Stack" \
-      "RCLOCAL" "Enable running scripts at startup from rc.local " \
-      "SSH" "Enable SSH server" \
-      "SYSTEMD" "Enable SystemD support"
+    menu --title "Services Menu" "${DIALOG_TYPE}" "Enables various services\n[ENTER to confirm]:" 14 70 6 \
+      "CASSANDRA" "Install the NoSQL server Cassandra from Apache " ${OFF} \
+      "KEYCHAIN" "Install Keychain, the OpenSSH key manager" ${OFF} \
+      "LAMP" "Install LAMP Stack" ${OFF} \
+      "RCLOCAL" "Enable running scripts at startup from rc.local " ${OFF} \
+      "SSH" "Enable SSH server" ${OFF} \
+      "SYSTEMD" "Enable SystemD support" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/services.sh
+++ b/pengwin-setup.d/services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SetupDir

--- a/pengwin-setup.d/settings.sh
+++ b/pengwin-setup.d/settings.sh
@@ -8,15 +8,15 @@ declare SetupDir
 
 function main() {
 
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Settings Menu" --menu "Change various settings in Pengwin\n[ENTER to confirm]:" 14 97 5 \
-      "EXPLORER" "Enable right-click on folders in Windows Explorer to open them in Pengwin  " \
-      "COLORTOOL" "Install ColorTool to set Windows console color schemes" \
-      "LANGUAGE" "Change default language and keyboard setting in Pengwin" \
-      "MOTD" "Configures the Message Of The Day behaviour" \
-      "SHELLS" "Install and configure zsh, csh, fish or readline improvements"
+    menu --title "Settings Menu" "${DIALOG_TYPE}" "Change various settings in Pengwin\n[ENTER to confirm]:" 14 97 5 \
+      "EXPLORER" "Enable right-click on folders in Windows Explorer to open them in Pengwin  " ${OFF} \
+      "COLORTOOL" "Install ColorTool to set Windows console color schemes" ${OFF} \
+      "LANGUAGE" "Change default language and keyboard setting in Pengwin" ${OFF} \
+      "MOTD" "Configures the Message Of The Day behaviour" ${OFF} \
+      "SHELLS" "Install and configure zsh, csh, fish or readline improvements" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/settings.sh
+++ b/pengwin-setup.d/settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/shell-opts.sh
+++ b/pengwin-setup.d/shell-opts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 function input_rc() {

--- a/pengwin-setup.d/shells.sh
+++ b/pengwin-setup.d/shells.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/shortcut.sh
+++ b/pengwin-setup.d/shortcut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Globals

--- a/pengwin-setup.d/synaptic.sh
+++ b/pengwin-setup.d/synaptic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "SYNAPTIC" --yesno "Would you like to install the Synaptic package manager? This provides a graphical front-end for the APT package management system" 8 80) then

--- a/pengwin-setup.d/terminal.sh
+++ b/pengwin-setup.d/terminal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare wHome

--- a/pengwin-setup.d/theme.sh
+++ b/pengwin-setup.d/theme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/tools.sh
+++ b/pengwin-setup.d/tools.sh
@@ -8,15 +8,15 @@ declare SetupDir
 
 function main() {
 
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Tools Menu" --menu "Install applications or servers\n[ENTER to confirm]:" 14 87 5 \
-      "ANSIBLE" "Install tools to deploy Ansible Playbooks" \
-      "CLOUDCLI" "Install CLI tools for cloud management (AWS, Azure, Terraform) " \
-      "DOCKER" "Install a secure bridge to Docker Desktop" \
-      "HOMEBREW" "Install the Homebrew package manager" \
-      "POWERSHELL" "Install PowerShell for Linux"
+    menu --title "Tools Menu" "${DIALOG_TYPE}" "Install applications or servers\n[ENTER to confirm]:" 14 87 5 \
+      "ANSIBLE" "Install tools to deploy Ansible Playbooks" ${OFF} \
+      "CLOUDCLI" "Install CLI tools for cloud management (AWS, Azure, Terraform) " ${OFF} \
+      "DOCKER" "Install a secure bridge to Docker Desktop" ${OFF} \
+      "HOMEBREW" "Install the Homebrew package manager" ${OFF} \
+      "POWERSHELL" "Install PowerShell for Linux" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/tools.sh
+++ b/pengwin-setup.d/tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/uninstall.sh
+++ b/pengwin-setup.d/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/pengwin-setup.d/uninstall.sh
+++ b/pengwin-setup.d/uninstall.sh
@@ -9,52 +9,52 @@ declare SetupDir
 function main() {
 
   local UninstallDir="${SetupDir}/uninstall"
-  # shellcheck disable=SC2155
+  # shellcheck disable=SC2155,SC2086
   local menu_choice=$(
 
-    menu --title "Uninstall Menu" --menu "Uninstall applications and packages installed by pengwin-setup\n[ENTER to confirm]:" 0 0 0 \
-      "ANSIBLE" "Remove Ansible Playbook deployment tools" \
-      "AWS" "Remove AWS CLI tools" \
-      "AZURE" "Remove Azure CLI tools" \
-      "BASH-RL" "Remove optimized Bash readline settings" \
-      "C++" "Remove Linux C/C++ programming support in Visual Studio and CLion    " \
-      "CASSANDRA" "Remove Cassandra NoSQL server" \
-      "COLORTOOL" "Remove ColorTool console color scheme setter" \
-      "DIGITALOCEAN" "Remove Digital Ocean CLI tools" \
-      "DOCKER" "Remove secure bridge between Pengwin and Docker Desktop" \
-      "DOTNET" "Remove Microsoft's .NET Core SDK and NuGet (if installed)" \
-      "FCITX" "Remove all fcitx improved non-Latin input support" \
-      "FISH" "Remove FISH Shell" \
-      "GO" "Remove Go language" \
-      "GUILIB" "Remove base GUI application libraries" \
-      "HIDPI" "Remove Qt and GTK HiDPI modifications" \
-      "HOMEBREW" "Remove the Homebrew package manager" \
-      "IBM" "Remove IBM Cloud CLI tools" \
-      "IBUS" "Remove all ibus improved non-Latin input support" \
-      "JAVA" "Remove SDKMan its installed Java SDKs" \
-      "KEYCHAIN" "Remove Keychain OpenSSH key manager" \
-      "KUBERNETES" "Remove Kubernetes tooling" \
-      "LAMP" "Remove LAMP stack" \
-      "MSEDIT" "Remove Microsoft Edit TUI editor" \
-      "NIM" "Remove choosenim and any installed Nim components" \
-      "NODEJS" "Remove Node.js, npm and Yarn (if installed)" \
-      "OPENSTACK" "Remove OpenStack CLI tools" \
-      "POETRY" "Remove Poetry" \
-      "POWERSHELL" "Remove Powershell for Linux" \
-      "PYENV" "Remove pyenv, its Python version(s) and modules" \
-      "RCLOCAL" "Remove rclocal support (the file /etc/rc.local) is kept" \
-      "RUBY" "Remove rbenv, Ruby version(s) and Rails (if installed)" \
-      "RUST" "Remove Rust and rustup toolchain installer" \
-      "STARTMENU" "Remove all Pengwin generated Windows Start Menu shortcuts" \
-      "SSH" "Remove SSH server" \
-      "SYSTEMD" "Disable SystemD support" \
-      "TERRAFORM" "Remove Terraform CLI tools" \
-      "VCXSRV" "Remove VcXsrv X-server" \
-      "VSCODE" "Remove Visual Studio Code for Linux" \
-      "WINTHEME" "Remove Windows 10 theme and LXAppearance" \
-      "WSLTTY" "Remove WSLtty" \
-      "X410" "Remove the X410 X-server autostart" \
-      "XFCE" "Remove XFCE Desktop environment"
+    menu --title "Uninstall Menu" "${DIALOG_TYPE}" "Uninstall applications and packages installed by pengwin-setup\n[ENTER to confirm]:" 0 0 0 \
+      "ANSIBLE" "Remove Ansible Playbook deployment tools" ${OFF} \
+      "AWS" "Remove AWS CLI tools" ${OFF} \
+      "AZURE" "Remove Azure CLI tools" ${OFF} \
+      "BASH-RL" "Remove optimized Bash readline settings" ${OFF} \
+      "C++" "Remove Linux C/C++ programming support in Visual Studio and CLion    " ${OFF} \
+      "CASSANDRA" "Remove Cassandra NoSQL server" ${OFF} \
+      "COLORTOOL" "Remove ColorTool console color scheme setter" ${OFF} \
+      "DIGITALOCEAN" "Remove Digital Ocean CLI tools" ${OFF} \
+      "DOCKER" "Remove secure bridge between Pengwin and Docker Desktop" ${OFF} \
+      "DOTNET" "Remove Microsoft's .NET Core SDK and NuGet (if installed)" ${OFF} \
+      "FCITX" "Remove all fcitx improved non-Latin input support" ${OFF} \
+      "FISH" "Remove FISH Shell" ${OFF} \
+      "GO" "Remove Go language" ${OFF} \
+      "GUILIB" "Remove base GUI application libraries" ${OFF} \
+      "HIDPI" "Remove Qt and GTK HiDPI modifications" ${OFF} \
+      "HOMEBREW" "Remove the Homebrew package manager" ${OFF} \
+      "IBM" "Remove IBM Cloud CLI tools" ${OFF} \
+      "IBUS" "Remove all ibus improved non-Latin input support" ${OFF} \
+      "JAVA" "Remove SDKMan its installed Java SDKs" ${OFF} \
+      "KEYCHAIN" "Remove Keychain OpenSSH key manager" ${OFF} \
+      "KUBERNETES" "Remove Kubernetes tooling" ${OFF} \
+      "LAMP" "Remove LAMP stack" ${OFF} \
+      "MSEDIT" "Remove Microsoft Edit TUI editor" ${OFF} \
+      "NIM" "Remove choosenim and any installed Nim components" ${OFF} \
+      "NODEJS" "Remove Node.js, npm and Yarn (if installed)" ${OFF} \
+      "OPENSTACK" "Remove OpenStack CLI tools" ${OFF} \
+      "POETRY" "Remove Poetry" ${OFF} \
+      "POWERSHELL" "Remove Powershell for Linux" ${OFF} \
+      "PYENV" "Remove pyenv, its Python version(s) and modules" ${OFF} \
+      "RCLOCAL" "Remove rclocal support (the file /etc/rc.local) is kept" ${OFF} \
+      "RUBY" "Remove rbenv, Ruby version(s) and Rails (if installed)" ${OFF} \
+      "RUST" "Remove Rust and rustup toolchain installer" ${OFF} \
+      "STARTMENU" "Remove all Pengwin generated Windows Start Menu shortcuts" ${OFF} \
+      "SSH" "Remove SSH server" ${OFF} \
+      "SYSTEMD" "Disable SystemD support" ${OFF} \
+      "TERRAFORM" "Remove Terraform CLI tools" ${OFF} \
+      "VCXSRV" "Remove VcXsrv X-server" ${OFF} \
+      "VSCODE" "Remove Visual Studio Code for Linux" ${OFF} \
+      "WINTHEME" "Remove Windows 10 theme and LXAppearance" ${OFF} \
+      "WSLTTY" "Remove WSLtty" ${OFF} \
+      "X410" "Remove the X410 X-server autostart" ${OFF} \
+      "XFCE" "Remove XFCE Desktop environment" ${OFF}
 
     # shellcheck disable=SC2188
     3>&1 1>&2 2>&3

--- a/pengwin-setup.d/vcxsrv.sh
+++ b/pengwin-setup.d/vcxsrv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 version="21.1.13"

--- a/pengwin-setup.d/x410.sh
+++ b/pengwin-setup.d/x410.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 # check if x410 exists

--- a/rpm/pengwin-setup.d/brew.sh
+++ b/rpm/pengwin-setup.d/brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 

--- a/rpm/pengwin-setup.d/colortool.sh
+++ b/rpm/pengwin-setup.d/colortool.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/dotnet.sh
+++ b/rpm/pengwin-setup.d/dotnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/editors.sh
+++ b/rpm/pengwin-setup.d/editors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare INSTALLED=false

--- a/rpm/pengwin-setup.d/explorer.sh
+++ b/rpm/pengwin-setup.d/explorer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/fcitx.sh
+++ b/rpm/pengwin-setup.d/fcitx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/fzf.sh
+++ b/rpm/pengwin-setup.d/fzf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/go.sh
+++ b/rpm/pengwin-setup.d/go.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "GO" --yesno "Would you like to download and install the latest Go from Google?" 8 70); then

--- a/rpm/pengwin-setup.d/gui.sh
+++ b/rpm/pengwin-setup.d/gui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/guilib.sh
+++ b/rpm/pengwin-setup.d/guilib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare WIN_CUR_VER

--- a/rpm/pengwin-setup.d/hidpi.sh
+++ b/rpm/pengwin-setup.d/hidpi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "HiDPI" --yesno "Would you like to configure Qt and GDK for HiDPI displays?" 8 85) then

--- a/rpm/pengwin-setup.d/home-backup.sh
+++ b/rpm/pengwin-setup.d/home-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/jetbrains-support.sh
+++ b/rpm/pengwin-setup.d/jetbrains-support.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SetupDir

--- a/rpm/pengwin-setup.d/keychain.sh
+++ b/rpm/pengwin-setup.d/keychain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/lamp.sh
+++ b/rpm/pengwin-setup.d/lamp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 function install_lamp() {

--- a/rpm/pengwin-setup.d/language.sh
+++ b/rpm/pengwin-setup.d/language.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/latex.sh
+++ b/rpm/pengwin-setup.d/latex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/maintenance.sh
+++ b/rpm/pengwin-setup.d/maintenance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/nim.sh
+++ b/rpm/pengwin-setup.d/nim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/nodejs.sh
+++ b/rpm/pengwin-setup.d/nodejs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SKIP_CONFIMATIONS

--- a/rpm/pengwin-setup.d/powershell.sh
+++ b/rpm/pengwin-setup.d/powershell.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 if (confirm --title "POWERSHELL" --yesno "Would you like to download and install Powershell?" 8 55); then

--- a/rpm/pengwin-setup.d/pythonpi.sh
+++ b/rpm/pengwin-setup.d/pythonpi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 function install_pyenv() {

--- a/rpm/pengwin-setup.d/ruby.sh
+++ b/rpm/pengwin-setup.d/ruby.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/rust.sh
+++ b/rpm/pengwin-setup.d/rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/services.sh
+++ b/rpm/pengwin-setup.d/services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare SetupDir

--- a/rpm/pengwin-setup.d/settings.sh
+++ b/rpm/pengwin-setup.d/settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/shell-opts.sh
+++ b/rpm/pengwin-setup.d/shell-opts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 function input_rc() {

--- a/rpm/pengwin-setup.d/shells.sh
+++ b/rpm/pengwin-setup.d/shells.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/shortcut.sh
+++ b/rpm/pengwin-setup.d/shortcut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Globals

--- a/rpm/pengwin-setup.d/terminal.sh
+++ b/rpm/pengwin-setup.d/terminal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 declare wHome

--- a/rpm/pengwin-setup.d/theme.sh
+++ b/rpm/pengwin-setup.d/theme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/tools.sh
+++ b/rpm/pengwin-setup.d/tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/uninstall.sh
+++ b/rpm/pengwin-setup.d/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 #Imported from common.h

--- a/rpm/pengwin-setup.d/vcxsrv.sh
+++ b/rpm/pengwin-setup.d/vcxsrv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 version="1.20.9.0"
@@ -47,10 +47,10 @@ EOF
   unset VcxsrvUrl
   unset wVcxsrvDir
   unset VcxsrvDir
-  
+
   # Avoid collision with the other XServer
   sudo rm -f /etc/profile.d/02-x410.sh
-  
+
   touch "${HOME}"/.should-restart
 else
   echo "Skipping VcxSrv"

--- a/rpm/pengwin-setup.d/x410.sh
+++ b/rpm/pengwin-setup.d/x410.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck source=./common.sh
+# shellcheck source=common.sh
 source "$(dirname "$0")/common.sh" "$@"
 
 # check if x410 exists


### PR DESCRIPTION
This pull request introduces a new `--multiple` option for the Pengwin setup scripts, allowing users to select multiple installers at once (restoring previous behavior). It also refactors dialog menu handling to support this new option, improves code documentation, and fixes some shellcheck source path references. Additionally, minor CI and workflow tweaks are included.

**Multiple Selection and Dialog Menu Enhancements:**

* Added `--multiple` option to allow users to select multiple installers simultaneously; updates to `pengwin-setup`, `pengwin-setup.d/common.sh`, and all menus to support this via new `DIALOG_TYPE` and `OFF` variables. [[1]](diffhunk://#diff-698d13fbb3dea836f5a3710c59f4491702bc8f2e5769d67b4d0ecf651b069283R20-R22) [[2]](diffhunk://#diff-698d13fbb3dea836f5a3710c59f4491702bc8f2e5769d67b4d0ecf651b069283L150-R164) [[3]](diffhunk://#diff-698d13fbb3dea836f5a3710c59f4491702bc8f2e5769d67b4d0ecf651b069283R244) [[4]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091R105-R109) [[5]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L316-L343) [[6]](diffhunk://#diff-86570b3813aab4b383f5f6a97c4724de8062591877c051d6702aa9a0dad70bf2L69-R76) [[7]](diffhunk://#diff-45adfa4276676fd509f2d20e8f7027c0b5e398e69d7cd1417ed1c2ef5d10a14cL285-R294)
* Updated shell completion and help text to reflect the new `--multiple` option. [[1]](diffhunk://#diff-6b9975ecaf368d89c55151008cc2e82add8b44a50e87e313a2d3dd6818e7ac8fL52-R52) [[2]](diffhunk://#diff-698d13fbb3dea836f5a3710c59f4491702bc8f2e5769d67b4d0ecf651b069283R244)

**Code Quality and Documentation:**

* Improved and clarified function documentation throughout `pengwin-setup.d/common.sh` for better maintainability and understanding. [[1]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L41-R43) [[2]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091R52-R53) [[3]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L168-R185) [[4]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L196-R216) [[5]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L230-R251) [[6]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L252-R274) [[7]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L274-R297) [[8]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L376-R416) [[9]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L403-R432) [[10]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L413-R448) [[11]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L432-R470) [[12]](diffhunk://#diff-4d8fd2f2b74d0ea765deab7b8b2288323787b5dca86f004630d581e90da32091L466-R521)
* Set default dialog type and OFF value in environment setup for consistent menu behavior.

**Shellcheck and Source Path Fixes:**

* Fixed `shellcheck` source path comments in multiple installer scripts for correct linting. [[1]](diffhunk://#diff-8f3223f5235d2cf394ebebe3b10d5c95981ae126f5de98b1bd36ad1c7e4953c1L3-R3) [[2]](diffhunk://#diff-96059710b4cb9ebeb2515ee871dc9140a1907db1cdd8ea5e6cf128785ed63931L3-R3) [[3]](diffhunk://#diff-15a45be56116e7973e16fd2109493ef317cc576a89964bf58d7093eeb81279f9L3-R3) [[4]](diffhunk://#diff-86570b3813aab4b383f5f6a97c4724de8062591877c051d6702aa9a0dad70bf2L3-R3) [[5]](diffhunk://#diff-b1c04a0d8368eadfaf78b15807cb99af12bd2f7d6a0d066d2b788801c1bde8efL3-R3) [[6]](diffhunk://#diff-070e28e7b14ea1297ee99c037098678429d7e33d4f887e3aa19fa0e65df3f4ebL3-R3) [[7]](diffhunk://#diff-052674f6dcfc859ca292a4910183cac577d7ade5b6a21c69fa6459af8f066527L3-R3)
* Updated shellcheck invocation in CI to ignore SC2218.

**CI and Workflow Adjustments:**

* Commented out the requirement for the `test` job in the CircleCI deploy workflow.